### PR TITLE
implements join feature only for string lists [#45]

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,3 +161,10 @@ This is a getter that returns underlying slice interface.
 list := golist.NewList([]int{3, 2, 1})
 fmt.Println(list.List())  // [3 2 1]
 ```
+
+## list.Join(joiner) string
+This only works with string data types, panics otherwise. `joiner` is a string used to join the list.
+```golang
+list := golist.NewList([]string{"Hello", "World"})
+fmt.Println(list.Join("-"))  // "Hello-World"
+```

--- a/join.go
+++ b/join.go
@@ -1,0 +1,13 @@
+package golist
+
+import "strings"
+
+func (arr *List) Join(joiner string) string {
+	switch arr.list.(type) {
+	case []string:
+		list := arr.list.([]string)
+		return strings.Join(list, joiner)
+	default:
+		panic("list.Join can only be used with strings")
+	}
+}

--- a/more_test.go
+++ b/more_test.go
@@ -393,3 +393,38 @@ func TestList(t *testing.T) {
 
 	}
 }
+
+func Test(t *testing.T) {
+	testCases := []struct {
+		Obj      *List
+		expected string
+		joiner   string
+	}{
+		{
+			Obj:      NewList([]string{"Hello", "world"}),
+			joiner:   ",",
+			expected: "Hello,world",
+		},
+		{
+			Obj:      NewList([]string{"Hello", "world"}),
+			joiner:   " ",
+			expected: "Hello world",
+		},
+		{
+			Obj:      NewList([]string{"Hello", "world"}),
+			joiner:   "-",
+			expected: "Hello-world",
+		},
+		{
+			Obj:      NewList([]string{"Hello", "world"}),
+			joiner:   "",
+			expected: "Helloworld",
+		},
+	}
+	for _, tC := range testCases {
+		got := tC.Obj.Join(tC.joiner)
+		if got != tC.expected {
+			t.Errorf("[Error TestJoin] : Got: %v, Expected: %v.\n", got, tC.expected)
+		}
+	}
+}


### PR DESCRIPTION
resolves #45 

works only on strings
```golang
list := golist.NewList([]string{"Hello", "World"})
fmt.Println(list.Join("-"))  // "Hello-World"
```