### PR TITLE
implements replace feature [#43]

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,3 +177,14 @@ This only works with string data types, panics otherwise. `joiner` is a string u
 list := golist.NewList([]string{"Hello", "World"})
 fmt.Println(list.Join("-"))  // "Hello-World"
 ```
+
+## list.Replace(x, i) error
+Replaces an element at index i with element x. returns error if index does not exist. index of `-1` is equivalent to last item. This method is equivalent to working with slice (`a`) `a[1] = 10`
+```golang
+list := golist.NewList([]string{"Hello", "World"})
+err := list.Replace("golang", -1)
+if err != nil {
+    fmt.Println(err)  // handle error
+}
+fmt.Println(list)  // ["Hello", "golang"]
+```

--- a/more_test.go
+++ b/more_test.go
@@ -428,3 +428,69 @@ func Test(t *testing.T) {
 		}
 	}
 }
+
+func TestReplace(t *testing.T) {
+	var vint int = 5
+	var vint32 int32 = 5
+	var vint64 int64 = 5
+	var vfloat32 float32 = 5
+	var vfloat64 float64 = 5
+
+	testCases := []struct {
+		Obj      *List
+		expected *List
+		replace  interface{}
+		index    int
+	}{
+		{
+			Obj:      NewList([]int{2, 3}),
+			expected: NewList([]int{vint, 3}),
+			replace:  vint,
+			index:    0,
+		},
+		{
+			Obj:      NewList([]int32{2, 3}),
+			expected: NewList([]int32{5, 3}),
+			replace:  vint32,
+			index:    0,
+		},
+		{
+			Obj:      NewList([]int64{2, 3}),
+			expected: NewList([]int64{2, 5}),
+			replace:  vint64,
+			index:    1,
+		},
+		{
+			Obj:      NewList([]float32{2, 3}),
+			expected: NewList([]float32{2, 5}),
+			replace:  vfloat32,
+			index:    -1,
+		},
+		{
+			Obj:      NewList([]float64{2, 3}),
+			expected: NewList([]float64{2, 5}),
+			replace:  vfloat64,
+			index:    1,
+		},
+		{
+			Obj:      NewList([]string{"Hello", "world"}),
+			expected: NewList([]string{"Hello", "golang"}),
+			replace:  "golang",
+			index:    -1,
+		},
+	}
+	for _, tC := range testCases {
+		err := tC.Obj.Replace(tC.replace, tC.index)
+		if err != nil {
+			t.Errorf("[Error TestReplace] : %v\n", err)
+		}
+		got := tC.Obj
+
+		for i := 0; i < got.Len(); i++ {
+			if got.Get(i) != tC.expected.Get(i) {
+				t.Errorf("[Error TestReplace] : Got: %v, Expected: %v.\n", got, tC.expected)
+			}
+		}
+
+	}
+}

--- a/replace.go
+++ b/replace.go
@@ -1,0 +1,76 @@
+package golist
+
+import "errors"
+
+func (arr *List) Replace(element interface{}, index int) error {
+	switch arr.list.(type) {
+	case []int:
+		list := arr.list.([]int)
+		item := element.(int)
+		if index >= len(list) || index < -1 {
+			return errors.New("Index out of range")
+		} else if index == -1 {
+			index = len(list) - 1
+		}
+		list[index] = item
+		arr.list = list
+		return nil
+	case []int32:
+		list := arr.list.([]int32)
+		item := element.(int32)
+		if index >= len(list) || index < -1 {
+			return errors.New("Index out of range")
+		} else if index == -1 {
+			index = len(list) - 1
+		}
+		list[index] = item
+		arr.list = list
+		return nil
+	case []int64:
+		list := arr.list.([]int64)
+		item := element.(int64)
+		if index >= len(list) || index < -1 {
+			return errors.New("Index out of range")
+		} else if index == -1 {
+			index = len(list) - 1
+		}
+		list[index] = item
+		arr.list = list
+		return nil
+	case []float32:
+		list := arr.list.([]float32)
+		item := element.(float32)
+		if index >= len(list) || index < -1 {
+			return errors.New("Index out of range")
+		} else if index == -1 {
+			index = len(list) - 1
+		}
+		list[index] = item
+		arr.list = list
+		return nil
+	case []float64:
+		list := arr.list.([]float64)
+		item := element.(float64)
+		if index >= len(list) || index < -1 {
+			return errors.New("Index out of range")
+		} else if index == -1 {
+			index = len(list) - 1
+		}
+		list[index] = item
+		arr.list = list
+		return nil
+	case []string:
+		list := arr.list.([]string)
+		item := element.(string)
+		if index >= len(list) || index < -1 {
+			return errors.New("Index out of range")
+		} else if index == -1 {
+			index = len(list) - 1
+		}
+		list[index] = item
+		arr.list = list
+		return nil
+	default:
+		return errors.New("unknown type")
+	}
+}


### PR DESCRIPTION
## list.Replace(x, i) error
Replaces an element at index i with element x. returns error if index does not exist. index of `-1` is equivalent to last item. This method is equivalent to working with slice (`a`) `a[1] = 10`
```golang
list := golist.NewList([]string{"Hello", "World"})
err := list.Replace("golang", -1)
if err != nil {
    fmt.Println(err)  // handle error
}
fmt.Println(list)  // ["Hello", "golang"]
```

resolves #43 