### PR TITLE
52 gcf list

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,3 +238,14 @@ Output
 2
 1
 ```
+
+## list.GCF() (interface{}, error)
+Returns the Greatest Common Factor (GCF) or Highest Common Factor (HCF) of the numbers in the list. Only works with numbers. Returns error if called on list of strings. Uses [Euclidean algorithm](https://en.wikipedia.org/wiki/Euclidean_algorithm)
+```golang
+list := golist.NewList([]string{10, 15, 5})
+gcf, err := list.GCF()
+if err != nil {
+    fmt.Println(err)  // handle error
+}
+fmt.Println(gcf)  // 5
+```

--- a/core/common.go
+++ b/core/common.go
@@ -1,0 +1,9 @@
+package core
+
+import (
+	"errors"
+)
+
+var (
+	ErrNotZeroOrPositive = errors.New("numbers must be zero or positive")
+)

--- a/core/float32list.go
+++ b/core/float32list.go
@@ -109,3 +109,24 @@ func MinFloat32(list *[]float32) (min float32) {
 	}
 	return
 }
+
+func GCFfloat32(list *[]float32) (gcf float32, err error) {
+	var count int
+	if len(*list) < 2 {
+		return (*list)[0], nil
+	}
+	count = len(*list)
+	gcf = (*list)[0]
+	for i := 1; i < count; i++ {
+		b := float64((*list)[i])
+		a := float64(gcf)
+		if a < 0 || b < 0 {
+			return 0, ErrNotZeroOrPositive
+		} else if a == 0 || b == 0 {
+			gcf = float32(a + b)
+		} else {
+			gcf = float32(_gcfFloat64(a, b))
+		}
+	}
+	return gcf, nil
+}

--- a/core/floatlist64.go
+++ b/core/floatlist64.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"errors"
+	"math"
 	"sort"
 )
 
@@ -107,4 +108,54 @@ func MinFloat64(list *[]float64) (min float64) {
 		}
 	}
 	return
+}
+
+func rounder(num float64) int {
+	return int(num + math.Copysign(0.5, num))
+}
+
+func RoundFloat64(num float64, precision int) float64 {
+	output := math.Pow(10, float64(precision))
+	return float64(rounder(num*output)) / output
+}
+
+func _gcfFloat64(a, b float64) float64 {
+	var h, l float64
+	if a > b {
+		h, l = a, b
+	} else {
+		h, l = b, a
+	}
+
+	for {
+		r := RoundFloat64(math.Mod(h, l), 4)
+		if r == 0 {
+			return l
+		} else {
+			h = l
+			l = r
+		}
+	}
+
+}
+
+func GCFfloat64(list *[]float64) (gcf float64, err error) {
+	var count int
+	if len(*list) < 2 {
+		return (*list)[0], nil
+	}
+	count = len(*list)
+	gcf = (*list)[0]
+	for i := 1; i < count; i++ {
+		b := (*list)[i]
+		a := gcf
+		if a < 0 || b < 0 {
+			return 0, ErrNotZeroOrPositive
+		} else if a == 0 || b == 0 {
+			gcf = a + b
+		} else {
+			gcf = _gcfFloat64(a, b)
+		}
+	}
+	return gcf, nil
 }

--- a/core/int32list.go
+++ b/core/int32list.go
@@ -108,3 +108,44 @@ func MinInt32(list *[]int32) (min int32) {
 	}
 	return
 }
+
+func _gcfInt32(a, b int32) int32 {
+	var h, l int32
+	if a > b {
+		h, l = a, b
+	} else {
+		h, l = b, a
+	}
+
+	for {
+		r := h % l
+		if r == 0 {
+			return l
+		} else {
+			h = l
+			l = r
+		}
+	}
+
+}
+
+func GCFInt32(list *[]int32) (gcf int32, err error) {
+	var count int
+	if len(*list) < 2 {
+		return (*list)[0], nil
+	}
+	count = len(*list)
+	gcf = (*list)[0]
+	for i := 1; i < count; i++ {
+		b := (*list)[i]
+		a := gcf
+		if a < 0 || b < 0 {
+			return 0, ErrNotZeroOrPositive
+		} else if a == 0 || b == 0 {
+			gcf = a + b
+		} else {
+			gcf = _gcfInt32(a, b)
+		}
+	}
+	return gcf, nil
+}

--- a/core/int64list.go
+++ b/core/int64list.go
@@ -108,3 +108,44 @@ func MinInt64(list *[]int64) (min int64) {
 	}
 	return
 }
+
+func _gcfInt64(a, b int64) int64 {
+	var h, l int64
+	if a > b {
+		h, l = a, b
+	} else {
+		h, l = b, a
+	}
+
+	for {
+		r := h % l
+		if r == 0 {
+			return l
+		} else {
+			h = l
+			l = r
+		}
+	}
+
+}
+
+func GCFInt64(list *[]int64) (gcf int64, err error) {
+	var count int
+	if len(*list) < 2 {
+		return (*list)[0], nil
+	}
+	count = len(*list)
+	gcf = (*list)[0]
+	for i := 1; i < count; i++ {
+		b := (*list)[i]
+		a := gcf
+		if a < 0 || b < 0 {
+			return 0, ErrNotZeroOrPositive
+		} else if a == 0 || b == 0 {
+			gcf = a + b
+		} else {
+			gcf = _gcfInt64(a, b)
+		}
+	}
+	return gcf, nil
+}

--- a/core/intlist.go
+++ b/core/intlist.go
@@ -108,3 +108,44 @@ func MinInt(list *[]int) (min int) {
 	}
 	return
 }
+
+func _gcfInt(a, b int) int {
+	var h, l int
+	if a > b {
+		h, l = a, b
+	} else {
+		h, l = b, a
+	}
+
+	for {
+		r := h % l
+		if r == 0 {
+			return l
+		} else {
+			h = l
+			l = r
+		}
+	}
+
+}
+
+func GCFInt(list *[]int) (gcf int, err error) {
+	var count int
+	if len(*list) < 2 {
+		return (*list)[0], nil
+	}
+	count = len(*list)
+	gcf = (*list)[0]
+	for i := 1; i < count; i++ {
+		b := (*list)[i]
+		a := gcf
+		if a < 0 || b < 0 {
+			return 0, ErrNotZeroOrPositive
+		} else if a == 0 || b == 0 {
+			gcf = a + b
+		} else {
+			gcf = _gcfInt(a, b)
+		}
+	}
+	return gcf, nil
+}

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,7 @@
+package golist
+
+import "errors"
+
+var (
+	ErrTypeNotsupported = errors.New("interface type should be []float32, []float64, []int32, []int, []int64, or []string")
+)

--- a/gcf.go
+++ b/gcf.go
@@ -1,0 +1,43 @@
+package golist
+
+import (
+	"errors"
+
+	"github.com/emylincon/golist/core"
+)
+
+func (arr *List) GCF() (gcf interface{}, err error) {
+
+	switch arr.list.(type) {
+	case []int:
+		list := arr.list.([]int)
+		return core.GCFInt(&list)
+
+	case []int32:
+		list := arr.list.([]int32)
+		return core.GCFInt32(&list)
+
+	case []int64:
+		list := arr.list.([]int64)
+		return core.GCFInt64(&list)
+
+	case []float32:
+		list := arr.list.([]float32)
+		return core.GCFfloat32(&list)
+
+	case []float64:
+		list := arr.list.([]float64)
+		return core.GCFfloat64(&list)
+
+	case []string:
+		return nil, errors.New("strings are not supported for this operation")
+
+	default:
+		return nil, ErrTypeNotsupported
+	}
+
+}
+
+func (arr *List) HCF() (gcf interface{}, err error) {
+	return arr.GCF()
+}

--- a/more_test.go
+++ b/more_test.go
@@ -494,3 +494,59 @@ func TestReplace(t *testing.T) {
 
 	}
 }
+
+func TestGCF(t *testing.T) {
+	var vint int = 5
+	var vint32 int32 = 5
+	var vint64 int64 = 5
+	var vfloat32 float32 = 5
+	var vfloat64 float64 = 5
+	var edge float64 = 0.3
+
+	testCases := []struct {
+		Obj      *List
+		expected interface{}
+	}{
+		{
+			Obj:      NewList([]int{10, 5, 25, 200}),
+			expected: vint,
+		},
+		// edge case
+		{
+			Obj:      NewList([]int{10, 5, 0, 0}),
+			expected: vint,
+		},
+		{
+			Obj:      NewList([]int32{10, 5, 25, 200}),
+			expected: vint32,
+		},
+		{
+			Obj:      NewList([]int64{10, 5, 25, 200}),
+			expected: vint64,
+		},
+		{
+			Obj:      NewList([]float32{10, 5, 25, 200}),
+			expected: vfloat32,
+		},
+		{
+			Obj:      NewList([]float64{10, 5, 25, 200}),
+			expected: vfloat64,
+		},
+		// edge case
+		{
+			Obj:      NewList([]float64{6.3, 12}),
+			expected: edge,
+		},
+		{
+			Obj:      NewList([]string{"Hello", "world"}),
+			expected: nil,
+		},
+	}
+	for _, tC := range testCases {
+		got, _ := tC.Obj.GCF()
+		if got != tC.expected {
+			t.Errorf("GCF Error : %v != %v", tC.expected, got)
+		}
+
+	}
+}


### PR DESCRIPTION
## list.GCF() (interface{}, error)
Returns the Greatest Common Factor (GCF) or Highest Common Factor (HCF) of the numbers in the list. Only works with numbers. Returns error if called on list of strings. Uses [Euclidean algorithm](https://en.wikipedia.org/wiki/Euclidean_algorithm)
```golang
list := golist.NewList([]string{10, 15, 5})
gcf, err := list.GCF()
if err != nil {
    fmt.Println(err)  // handle error
}
fmt.Println(gcf)  // 5
```

closes #52 