### PR TITLE
implemented lcm [#51]

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,10 +242,21 @@ Output
 ## list.GCF() (interface{}, error)
 Returns the Greatest Common Factor (GCF) or Highest Common Factor (HCF) of the numbers in the list. Only works with numbers. Returns error if called on list of strings. Uses [Euclidean algorithm](https://en.wikipedia.org/wiki/Euclidean_algorithm)
 ```golang
-list := golist.NewList([]string{10, 15, 5})
+list := golist.NewList([]int{10, 15, 5})
 gcf, err := list.GCF()
 if err != nil {
     fmt.Println(err)  // handle error
 }
 fmt.Println(gcf)  // 5
+```
+
+## list.LCM() (interface{}, error)
+Returns the [Least Common Multiple (LCM)](https://mathworld.wolfram.com/LeastCommonMultiple.html) of the numbers in the list. Only works with numbers. Returns error if called on list of strings. Uses [Euclidean algorithm](https://en.wikipedia.org/wiki/Euclidean_algorithm)
+```golang
+list := golist.NewList([]int{10, 15, 5})
+lcm, err := list.LCM()
+if err != nil {
+    fmt.Println(err)  // handle error
+}
+fmt.Println(lcm)  // 30
 ```

--- a/core/float32list.go
+++ b/core/float32list.go
@@ -110,23 +110,31 @@ func MinFloat32(list *[]float32) (min float32) {
 	return
 }
 
-func GCFfloat32(list *[]float32) (gcf float32, err error) {
+func LcmHcfFloat32(list *[]float32, get func(a, b float64) float64) (result float32, err error) {
 	var count int
 	if len(*list) < 2 {
 		return (*list)[0], nil
 	}
 	count = len(*list)
-	gcf = (*list)[0]
+	result = (*list)[0]
 	for i := 1; i < count; i++ {
 		b := float64((*list)[i])
-		a := float64(gcf)
+		a := float64(result)
 		if a < 0 || b < 0 {
 			return 0, ErrNotZeroOrPositive
 		} else if a == 0 || b == 0 {
-			gcf = float32(a + b)
+			result = float32(a + b)
 		} else {
-			gcf = float32(_gcfFloat64(a, b))
+			result = float32(get(a, b))
 		}
 	}
-	return gcf, nil
+	return result, nil
+}
+
+func GCFFloat32(list *[]float32) (gcf float32, err error) {
+	return LcmHcfFloat32(list, _gcfFloat64)
+}
+
+func LCMFloat32(list *[]float32) (lcm float32, err error) {
+	return LcmHcfFloat32(list, _lcmFloat64)
 }

--- a/core/floatlist64.go
+++ b/core/floatlist64.go
@@ -139,23 +139,38 @@ func _gcfFloat64(a, b float64) float64 {
 
 }
 
-func GCFfloat64(list *[]float64) (gcf float64, err error) {
+func LcmHcfFloat64(list *[]float64, get func(a, b float64) float64) (result float64, err error) {
 	var count int
 	if len(*list) < 2 {
 		return (*list)[0], nil
 	}
 	count = len(*list)
-	gcf = (*list)[0]
+	result = (*list)[0]
 	for i := 1; i < count; i++ {
 		b := (*list)[i]
-		a := gcf
+		a := result
 		if a < 0 || b < 0 {
 			return 0, ErrNotZeroOrPositive
 		} else if a == 0 || b == 0 {
-			gcf = a + b
+			result = a + b
 		} else {
-			gcf = _gcfFloat64(a, b)
+			result = get(a, b)
 		}
 	}
-	return gcf, nil
+	return result, nil
+}
+
+func GCFFloat64(list *[]float64) (gcf float64, err error) {
+	return LcmHcfFloat64(list, _gcfFloat64)
+}
+
+func _lcmFloat64(a, b float64) float64 {
+	if a == 0 && b == 0 {
+		return 0
+	}
+	return (a * b) / _gcfFloat64(a, b)
+}
+
+func LCMFloat64(list *[]float64) (lcm float64, err error) {
+	return LcmHcfFloat64(list, _lcmFloat64)
 }

--- a/core/int32list.go
+++ b/core/int32list.go
@@ -109,6 +109,27 @@ func MinInt32(list *[]int32) (min int32) {
 	return
 }
 
+func LcmHcfInt32(list *[]int32, get func(a, b int32) int32) (result int32, err error) {
+	var count int
+	if len(*list) < 2 {
+		return (*list)[0], nil
+	}
+	count = len(*list)
+	result = (*list)[0]
+	for i := 1; i < count; i++ {
+		b := (*list)[i]
+		a := result
+		if a < 0 || b < 0 {
+			return 0, ErrNotZeroOrPositive
+		} else if a == 0 || b == 0 {
+			result = a + b
+		} else {
+			result = get(a, b)
+		}
+	}
+	return result, nil
+}
+
 func _gcfInt32(a, b int32) int32 {
 	var h, l int32
 	if a > b {
@@ -130,22 +151,16 @@ func _gcfInt32(a, b int32) int32 {
 }
 
 func GCFInt32(list *[]int32) (gcf int32, err error) {
-	var count int
-	if len(*list) < 2 {
-		return (*list)[0], nil
+	return LcmHcfInt32(list, _gcfInt32)
+}
+
+func _lcmInt32(a, b int32) int32 {
+	if a == 0 && b == 0 {
+		return 0
 	}
-	count = len(*list)
-	gcf = (*list)[0]
-	for i := 1; i < count; i++ {
-		b := (*list)[i]
-		a := gcf
-		if a < 0 || b < 0 {
-			return 0, ErrNotZeroOrPositive
-		} else if a == 0 || b == 0 {
-			gcf = a + b
-		} else {
-			gcf = _gcfInt32(a, b)
-		}
-	}
-	return gcf, nil
+	return (a * b) / _gcfInt32(a, b)
+}
+
+func LCMInt32(list *[]int32) (lcm int32, err error) {
+	return LcmHcfInt32(list, _lcmInt32)
 }

--- a/core/int64list.go
+++ b/core/int64list.go
@@ -109,6 +109,27 @@ func MinInt64(list *[]int64) (min int64) {
 	return
 }
 
+func LcmHcfInt64(list *[]int64, get func(a, b int64) int64) (result int64, err error) {
+	var count int
+	if len(*list) < 2 {
+		return (*list)[0], nil
+	}
+	count = len(*list)
+	result = (*list)[0]
+	for i := 1; i < count; i++ {
+		b := (*list)[i]
+		a := result
+		if a < 0 || b < 0 {
+			return 0, ErrNotZeroOrPositive
+		} else if a == 0 || b == 0 {
+			result = a + b
+		} else {
+			result = get(a, b)
+		}
+	}
+	return result, nil
+}
+
 func _gcfInt64(a, b int64) int64 {
 	var h, l int64
 	if a > b {
@@ -130,22 +151,16 @@ func _gcfInt64(a, b int64) int64 {
 }
 
 func GCFInt64(list *[]int64) (gcf int64, err error) {
-	var count int
-	if len(*list) < 2 {
-		return (*list)[0], nil
+	return LcmHcfInt64(list, _gcfInt64)
+}
+
+func _lcmInt64(a, b int64) int64 {
+	if a == 0 && b == 0 {
+		return 0
 	}
-	count = len(*list)
-	gcf = (*list)[0]
-	for i := 1; i < count; i++ {
-		b := (*list)[i]
-		a := gcf
-		if a < 0 || b < 0 {
-			return 0, ErrNotZeroOrPositive
-		} else if a == 0 || b == 0 {
-			gcf = a + b
-		} else {
-			gcf = _gcfInt64(a, b)
-		}
-	}
-	return gcf, nil
+	return (a * b) / _gcfInt64(a, b)
+}
+
+func LCMInt64(list *[]int64) (lcm int64, err error) {
+	return LcmHcfInt64(list, _lcmInt64)
 }

--- a/core/intlist.go
+++ b/core/intlist.go
@@ -109,6 +109,27 @@ func MinInt(list *[]int) (min int) {
 	return
 }
 
+func LcmHcfInt(list *[]int, get func(a, b int) int) (result int, err error) {
+	var count int
+	if len(*list) < 2 {
+		return (*list)[0], nil
+	}
+	count = len(*list)
+	result = (*list)[0]
+	for i := 1; i < count; i++ {
+		b := (*list)[i]
+		a := result
+		if a < 0 || b < 0 {
+			return 0, ErrNotZeroOrPositive
+		} else if a == 0 || b == 0 {
+			result = a + b
+		} else {
+			result = get(a, b)
+		}
+	}
+	return result, nil
+}
+
 func _gcfInt(a, b int) int {
 	var h, l int
 	if a > b {
@@ -130,22 +151,16 @@ func _gcfInt(a, b int) int {
 }
 
 func GCFInt(list *[]int) (gcf int, err error) {
-	var count int
-	if len(*list) < 2 {
-		return (*list)[0], nil
+	return LcmHcfInt(list, _gcfInt)
+}
+
+func _lcmInt(a, b int) int {
+	if a == 0 && b == 0 {
+		return 0
 	}
-	count = len(*list)
-	gcf = (*list)[0]
-	for i := 1; i < count; i++ {
-		b := (*list)[i]
-		a := gcf
-		if a < 0 || b < 0 {
-			return 0, ErrNotZeroOrPositive
-		} else if a == 0 || b == 0 {
-			gcf = a + b
-		} else {
-			gcf = _gcfInt(a, b)
-		}
-	}
-	return gcf, nil
+	return (a * b) / _gcfInt(a, b)
+}
+
+func LCMInt(list *[]int) (lcm int, err error) {
+	return LcmHcfInt(list, _lcmInt)
 }

--- a/lcm.go
+++ b/lcm.go
@@ -6,28 +6,28 @@ import (
 	"github.com/emylincon/golist/core"
 )
 
-func (arr *List) GCF() (gcf interface{}, err error) {
+func (arr *List) LCM() (lcm interface{}, err error) {
 
 	switch arr.list.(type) {
 	case []int:
 		list := arr.list.([]int)
-		return core.GCFInt(&list)
+		return core.LCMInt(&list)
 
 	case []int32:
 		list := arr.list.([]int32)
-		return core.GCFInt32(&list)
+		return core.LCMInt32(&list)
 
 	case []int64:
 		list := arr.list.([]int64)
-		return core.GCFInt64(&list)
+		return core.LCMInt64(&list)
 
 	case []float32:
 		list := arr.list.([]float32)
-		return core.GCFFloat32(&list)
+		return core.LCMFloat32(&list)
 
 	case []float64:
 		list := arr.list.([]float64)
-		return core.GCFFloat64(&list)
+		return core.LCMFloat64(&list)
 
 	case []string:
 		return nil, errors.New("strings are not supported for this operation")
@@ -36,8 +36,4 @@ func (arr *List) GCF() (gcf interface{}, err error) {
 		return nil, ErrTypeNotsupported
 	}
 
-}
-
-func (arr *List) HCF() (gcf interface{}, err error) {
-	return arr.GCF()
 }

--- a/more_test.go
+++ b/more_test.go
@@ -502,6 +502,7 @@ func TestGCF(t *testing.T) {
 	var vfloat32 float32 = 5
 	var vfloat64 float64 = 5
 	var edge float64 = 0.3
+	var edge2 float64 = 0
 
 	testCases := []struct {
 		Obj      *List
@@ -537,6 +538,11 @@ func TestGCF(t *testing.T) {
 			Obj:      NewList([]float64{6.3, 12}),
 			expected: edge,
 		},
+		// edge case
+		{
+			Obj:      NewList([]float64{0, 0}),
+			expected: edge2,
+		},
 		{
 			Obj:      NewList([]string{"Hello", "world"}),
 			expected: nil,
@@ -546,6 +552,69 @@ func TestGCF(t *testing.T) {
 		got, _ := tC.Obj.GCF()
 		if got != tC.expected {
 			t.Errorf("GCF Error : %v != %v", tC.expected, got)
+		}
+
+	}
+}
+
+func TestLCM(t *testing.T) {
+	var vint int = 200
+	var vint32 int32 = 200
+	var vint64 int64 = 200
+	var vfloat32 float32 = 200
+	var vfloat64 float64 = 200
+	var edge float64 = 252
+	var edge1 int = 10
+	var edge2 float64 = 0
+
+	testCases := []struct {
+		Obj      *List
+		expected interface{}
+	}{
+		{
+			Obj:      NewList([]int{10, 5, 25, 200}),
+			expected: vint,
+		},
+		// edge case
+		{
+			Obj:      NewList([]int{10, 5, 0, 0}),
+			expected: edge1,
+		},
+		{
+			Obj:      NewList([]int32{10, 5, 25, 200}),
+			expected: vint32,
+		},
+		{
+			Obj:      NewList([]int64{10, 5, 25, 200}),
+			expected: vint64,
+		},
+		{
+			Obj:      NewList([]float32{10, 5, 25, 200}),
+			expected: vfloat32,
+		},
+		{
+			Obj:      NewList([]float64{10, 5, 25, 200}),
+			expected: vfloat64,
+		},
+		// edge case
+		{
+			Obj:      NewList([]float64{6.3, 12}),
+			expected: edge,
+		},
+		// edge case
+		{
+			Obj:      NewList([]float64{0, 0}),
+			expected: edge2,
+		},
+		{
+			Obj:      NewList([]string{"Hello", "world"}),
+			expected: nil,
+		},
+	}
+	for _, tC := range testCases {
+		got, _ := tC.Obj.LCM()
+		if got != tC.expected {
+			t.Errorf("LCM Error : %v != %v", tC.expected, got)
 		}
 
 	}


### PR DESCRIPTION
## list.LCM() (interface{}, error)
Returns the [Least Common Multiple (LCM)](https://mathworld.wolfram.com/LeastCommonMultiple.html) of the numbers in the list. Only works with numbers. Returns error if called on list of strings. Uses [Euclidean algorithm](https://en.wikipedia.org/wiki/Euclidean_algorithm)
```golang
list := golist.NewList([]int{10, 15, 5})
lcm, err := list.LCM()
if err != nil {
    fmt.Println(err)  // handle error
}
fmt.Println(lcm)  // 30
```

closes #51 