### PR TITLE
implements combinations max [#79]

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ list := golist.NewList([]string{"Hello", "World"})
 fmt.Println(list.Contains("okay"))  // false
 ```
 
-## list.Combinations(n int, joiner string) *golist.List
+## list.Combinations(n int, joiner string) (*golist.List, error)
 This is adapted from [Link](https://github.com/mxschmitt/golang-combinations). `joiner` is a string used to join the strings. Combinations returns combinations of n number of elements for a given string array.e.g if `n=2` it will return only 2 combined elements.
 Futhermore `NewList([]string{"a", "b", "c"}).Combinations(2, "") = ["ab", "ac", "bc"]`.
 * For `n < 1`, it equals to All and returns all combinations.
@@ -304,7 +304,15 @@ list := NewList([]string{"a", "b", "c"})
 combinedList := list.Combinations(2, " ")
 fmt.Println(combinedList)  // ["a b", "a c", "b c"]
 combinedList = list.Combinations(2, ",")
-fmt.Println(combinedList)  // ["a,b", "a,c", "b,c"]
+fmt.Println(combinedList)  // ["a,b", "a,c", "b,c"] <nil>
+```
+
+## list.CombinationsMax(n int, joiner string) (*golist.List, error)
+Variation of `list.Combinations`. Difference is that for a given `n`, it returns combination lengths <= n, rather than only n.
+
+```golang
+list:= golist.NewList([]string{"a", "b", "c"})
+fmt.Println(list.CombinationsMax(2, "")) // ["a", "b", "ab", "c", "ac", "bc"] <nil>
 ```
 
 ## list.IsEqual(other *golist.List) bool

--- a/combination.go
+++ b/combination.go
@@ -7,7 +7,7 @@ import (
 // adapted from https://github.com/mxschmitt/golang-combinations
 // Combinations returns combinations of n number of elements for a given string array.
 // e.g if n=2 it will return only 2 combined elements :=
-// futhermore NewList([]string{"a", "b", "c"}).Combinations(2) = ["ab", "ac", "bc"]
+// futhermore NewList([]string{"a", "b", "c"}).Combinations(2, "") = ["ab", "ac", "bc"]
 // For n < 1, it equals to All and returns all combinations.
 // for n > len(list); n = len(list)
 func (arr *List) Combinations(n int, joiner string) (*List, error) {
@@ -18,6 +18,28 @@ func (arr *List) Combinations(n int, joiner string) (*List, error) {
 		list := arr.list.([]string)
 		set := core.SetString(list)
 		list = core.CombinationsString(set, n, joiner)
+		return NewList(list), nil
+
+	default:
+		return nil, ErrTypeNotsupported
+	}
+
+}
+
+// adapted from https://github.com/mxschmitt/golang-combinations
+// CombinationsMax returns combinations of n number of elements for a given string array.
+// e.g if n=2 it will return combinations <= 2
+// futhermore NewList([]string{"a", "b", "c"}).CombinationsMax(2, "") = ["a", "b", "c", "ab", "ac", "bc"]
+// For n < 1, it equals to All and returns all combinations.
+// for n > len(list); n = len(list)
+func (arr *List) CombinationsMax(n int, joiner string) (*List, error) {
+
+	switch arr.list.(type) {
+
+	case []string:
+		list := arr.list.([]string)
+		set := core.SetString(list)
+		list = core.CombinationsStringMax(set, n, joiner)
 		return NewList(list), nil
 
 	default:

--- a/core/stringlist.go
+++ b/core/stringlist.go
@@ -155,6 +155,43 @@ func CombinationsString(set []string, n int, joiner string) (subsets []string) {
 	return subsets
 }
 
+// CombinationsStringMax: should return combinations of max length.
+// For example: a list of [a, b, c] with max combination 2, should return 1 and 2 combinations.
+// i.e combinations length <= n
+// adapted from https://github.com/mxschmitt/golang-combinations
+func CombinationsStringMax(set []string, n int, joiner string) (subsets []string) {
+	length := uint(len(set))
+
+	if n > len(set) {
+		n = len(set)
+	}
+
+	// Go through all possible combinations of objects
+	// from 1 (only first object in subset) to 2^length (all objects in subset)
+	for subsetBits := 1; subsetBits < (1 << length); subsetBits++ {
+		if n > 0 && bits.OnesCount(uint(subsetBits)) > n {
+			continue
+		}
+
+		var subset string
+
+		for object := uint(0); object < length; object++ {
+			// checks if object is contained in subset
+			// by checking if bit 'object' is set in subsetBits
+			if (subsetBits>>object)&1 == 1 {
+				// add object to subset
+				subset += set[object] + joiner
+			}
+		}
+		// remove unwanted joiner and add subset to subsets
+		if len(joiner) != 0 {
+			subset = subset[:len(subset)-1]
+		}
+		subsets = append(subsets, subset)
+	}
+	return subsets
+}
+
 // returns a set of slice i.e removes duplicates
 func SetString(list []string) (set []string) {
 	keys := map[string]bool{}

--- a/list_test.go
+++ b/list_test.go
@@ -89,45 +89,38 @@ func TestReverseSort(t *testing.T) {
 	reverse := true
 	testCases := []struct {
 		Obj      List
-		expected interface{}
+		expected List
 	}{
 		{
 			Obj:      *NewList([]int{2, 3, 4}),
-			expected: []int{4, 3, 2},
+			expected: *NewList([]int{4, 3, 2}),
 		},
 		{
 			Obj:      *NewList([]int32{2, 3, 4}),
-			expected: []int32{4, 3, 2},
+			expected: *NewList([]int32{4, 3, 2}),
 		},
 		{
 			Obj:      *NewList([]int64{2, 3, 4}),
-			expected: []int64{4, 3, 2},
+			expected: *NewList([]int64{4, 3, 2}),
 		},
 		{
 			Obj:      *NewList([]float32{2, 3, 4}),
-			expected: []float32{4, 3, 2},
+			expected: *NewList([]float32{4, 3, 2}),
 		},
 		{
 			Obj:      *NewList([]float64{2, 3, 4}),
-			expected: []float64{4, 3, 2},
+			expected: *NewList([]float64{4, 3, 2}),
 		},
 		{
 			Obj:      *NewList([]string{"2", "3", "4"}),
-			expected: []string{"4", "3", "2"},
+			expected: *NewList([]string{"4", "3", "2"}),
 		},
 	}
 	for _, tC := range testCases {
 		tC.Obj.Sort(reverse)
-		got, err := tC.Obj.Last()
-		if err != nil {
-			t.Errorf("[Getting Last Error] %v", err)
-		}
-		expected, err := NewList(tC.expected).Last()
-		if err != nil {
-			t.Errorf("[Getting Last Error] %v", err)
-		}
-		if got != expected {
-			t.Errorf("Error [TestReverseSort], Got: %v, Expected: %v | %v, %v.\n", got, expected, tC.Obj.list, tC.expected)
+		got := tC.Obj
+		if !got.IsEqual(&tC.expected) {
+			t.Errorf("Error [TestReverseSort], Got: %v, Expected: %v.\n", &got, &tC.expected)
 		}
 
 	}
@@ -231,43 +224,43 @@ func TestInsert(t *testing.T) {
 
 	testCases := []struct {
 		Obj      List
-		expected interface{}
+		expected List
 		insert   interface{}
 		index    int
 	}{
 		{
 			Obj:      *NewList([]int{2, 3, 4}),
-			expected: []int{2, vint, 3, 4},
+			expected: *NewList([]int{2, vint, 3, 4}),
 			insert:   vint,
 			index:    1,
 		},
 		{
 			Obj:      *NewList([]int32{2, 3, 4}),
-			expected: []int32{2, 3, vint32, 4},
+			expected: *NewList([]int32{2, 3, vint32, 4}),
 			insert:   vint32,
 			index:    2,
 		},
 		{
 			Obj:      *NewList([]int64{2, 3, 4}),
-			expected: []int64{2, 3, 4, vint64},
+			expected: *NewList([]int64{2, 3, 4, vint64}),
 			insert:   vint64,
 			index:    3,
 		},
 		{
 			Obj:      *NewList([]float32{2, 3, 4}),
-			expected: []float32{vfloat32, 2, 3, 4},
+			expected: *NewList([]float32{vfloat32, 2, 3, 4}),
 			insert:   vfloat32,
 			index:    0,
 		},
 		{
 			Obj:      *NewList([]float64{2, 3, 4}),
-			expected: []float64{vfloat64, 2, 3, 4},
+			expected: *NewList([]float64{vfloat64, 2, 3, 4}),
 			insert:   vfloat64,
 			index:    0,
 		},
 		{
 			Obj:      *NewList([]string{"2", "3", "4"}),
-			expected: []string{vstring, "2", "3", "4"},
+			expected: *NewList([]string{vstring, "2", "3", "4"}),
 			insert:   vstring,
 			index:    0,
 		},
@@ -277,64 +270,9 @@ func TestInsert(t *testing.T) {
 		if err != nil {
 			t.Errorf("[Error Inserting] : %v", err)
 		}
-
-		switch tC.Obj.list.(type) {
-		case []int:
-			list := tC.Obj.list.([]int)
-			compare := tC.expected.([]int)
-			for i, v := range list {
-				if v != compare[i] {
-					t.Errorf("[Error Inserting | not equal] : Got: %v, Expected: %v.\n", list, tC.expected)
-				}
-			}
-
-		case []int32:
-			list := tC.Obj.list.([]int32)
-			compare := tC.expected.([]int32)
-			for i, v := range list {
-				if v != compare[i] {
-					t.Errorf("[Error Inserting | not equal] : Got: %v, Expected: %v.\n", list, tC.expected)
-				}
-			}
-
-		case []int64:
-			list := tC.Obj.list.([]int64)
-			compare := tC.expected.([]int64)
-			for i, v := range list {
-				if v != compare[i] {
-					t.Errorf("[Test Failed | not equal] : Got: %v, Expected: %v.\n", list, tC.expected)
-				}
-			}
-
-		case []float32:
-			list := tC.Obj.list.([]float32)
-			compare := tC.expected.([]float32)
-			for i, v := range list {
-				if v != compare[i] {
-					t.Errorf("[Test Failed  | not equal] : Got: %v, Expected: %v.\n", list, tC.expected)
-				}
-			}
-
-		case []float64:
-			list := tC.Obj.list.([]float64)
-			compare := tC.expected.([]float64)
-			for i, v := range list {
-				if v != compare[i] {
-					t.Errorf("[Test Failed  | not equal] : Got: %v, Expected: %v.\n", list, tC.expected)
-				}
-			}
-
-		case []string:
-			list := tC.Obj.list.([]string)
-			compare := tC.expected.([]string)
-			for i, v := range list {
-				if v != compare[i] {
-					t.Errorf("[Error Inserting | not equal] : Got: %v, Expected: %v.\n", list, tC.expected)
-				}
-			}
-
-		default:
-			return
+		got := tC.Obj
+		if !got.IsEqual(&tC.expected) {
+			t.Errorf("[Error Inserting | not equal] : Got: %v, Expected: %v.\n", &got, &tC.expected)
 		}
 
 	}
@@ -380,12 +318,8 @@ func TestSorted(t *testing.T) {
 	for _, tC := range testCases {
 		got := tC.Obj.Sorted(tC.reverse)
 
-		for i := 0; i < got.Len(); i++ {
-			Gotitem := got.Get(i)
-			Expecteditem := tC.expected.Get(i)
-			if Gotitem != Expecteditem {
-				t.Errorf("Error [TestSorted] Got: %v Expected: %v \n.", got, tC.expected)
-			}
+		if !got.IsEqual(tC.expected) {
+			t.Errorf("Error [TestSorted] Got: %v Expected: %v \n.", got, tC.expected)
 		}
 
 	}
@@ -568,10 +502,36 @@ func TestCombinations(t *testing.T) {
 	for _, tC := range testCases {
 		got, _ := tC.Obj.Combinations(tC.no, "")
 
-		for i := 0; i < got.Len(); i++ {
-			if got.Get(i) != tC.expected.Get(i) {
-				t.Errorf("[Failed TestCombinations] : Got: %v, Expected: %v.\n", got, &tC.expected)
-			}
+		if !got.IsEqual(&tC.expected) {
+			t.Errorf("[Failed TestCombinations] : Got: %v, Expected: %v.\n", got, &tC.expected)
+		}
+
+	}
+}
+
+func TestCombinationsMax(t *testing.T) {
+
+	testCases := []struct {
+		Obj      List
+		no       int
+		expected List
+	}{
+		{
+			Obj:      *NewList([]string{"a", "b", "c"}),
+			no:       2,
+			expected: *NewList([]string{"a", "b", "c", "ab", "ac", "bc"}),
+		},
+		{
+			Obj:      *NewList([]string{"a", "b", "c"}),
+			no:       3,
+			expected: *NewList([]string{"a", "b", "c", "ab", "ac", "bc", "abc"}),
+		},
+	}
+	for _, tC := range testCases {
+		got, _ := tC.Obj.CombinationsMax(tC.no, "")
+
+		if !got.Sorted(false).IsEqual(tC.expected.Sorted(false)) {
+			t.Errorf("[Failed TestCombinationsMax] : Got: %v, Expected: %v.\n", got, &tC.expected)
 		}
 
 	}


### PR DESCRIPTION
## list.CombinationsMax(n int, joiner string) (*golist.List, error)
Variation of `list.Combinations`. Difference is that for a given `n`, it returns combination lengths <= n, rather than only n.

```golang
list:= golist.NewList([]string{"a", "b", "c"})
fmt.Println(list.CombinationsMax(2, "")) // ["a", "b", "ab", "c", "ac", "bc"] <nil>
```

closes #79 