### PR TITLE
83 sum list

### DIFF
--- a/ListSum.go
+++ b/ListSum.go
@@ -1,0 +1,61 @@
+package golist
+
+import "github.com/emylincon/golist/core"
+
+// ListSum returns the sum of contents of two lists
+func (arr *List) ListSum(other *List) (*List, error) {
+
+	switch arr.list.(type) {
+	case []int:
+		list := arr.list.([]int)
+		otherArr, ok := other.list.([]int)
+		if !ok {
+			return nil, ErrListsNotOfSameType
+		}
+		sum := core.ListSumInt(list, otherArr)
+		return NewList(sum), nil
+
+	case []int32:
+		list := arr.list.([]int32)
+		otherArr, ok := other.list.([]int32)
+		if !ok {
+			return nil, ErrListsNotOfSameType
+		}
+		sum := core.ListSumInt32(list, otherArr)
+		return NewList(sum), nil
+
+	case []int64:
+		list := arr.list.([]int64)
+		otherArr, ok := other.list.([]int64)
+		if !ok {
+			return nil, ErrListsNotOfSameType
+		}
+		sum := core.ListSumInt64(list, otherArr)
+		return NewList(sum), nil
+
+	case []float32:
+		list := arr.list.([]float32)
+		otherArr, ok := other.list.([]float32)
+		if !ok {
+			return nil, ErrListsNotOfSameType
+		}
+		sum := core.ListSumFloat32(list, otherArr)
+		return NewList(sum), nil
+
+	case []float64:
+		list := arr.list.([]float64)
+		otherArr, ok := other.list.([]float64)
+		if !ok {
+			return nil, ErrListsNotOfSameType
+		}
+		sum := core.ListSumFloat64(list, otherArr)
+		return NewList(sum), nil
+
+	case []string:
+		return nil, ErrStringsNotsupported
+
+	default:
+		return nil, ErrTypeNotsupported
+	}
+
+}

--- a/ListSum.go
+++ b/ListSum.go
@@ -1,6 +1,19 @@
 package golist
 
-import "github.com/emylincon/golist/core"
+import (
+	"github.com/emylincon/golist/core"
+)
+
+// validateListSum validates
+func validateListSum(ok bool, listLen, otherLen int) error {
+	if !ok {
+		return ErrListsNotOfSameType
+	}
+	if listLen != otherLen {
+		return ErrListsNotOfSameLen
+	}
+	return nil
+}
 
 // ListSum returns the sum of contents of two lists
 func (arr *List) ListSum(other *List) (*List, error) {
@@ -9,8 +22,9 @@ func (arr *List) ListSum(other *List) (*List, error) {
 	case []int:
 		list := arr.list.([]int)
 		otherArr, ok := other.list.([]int)
-		if !ok {
-			return nil, ErrListsNotOfSameType
+		err := validateListSum(ok, arr.Len(), other.Len())
+		if err != nil {
+			return &List{}, err
 		}
 		sum := core.ListSumInt(list, otherArr)
 		return NewList(sum), nil
@@ -18,8 +32,9 @@ func (arr *List) ListSum(other *List) (*List, error) {
 	case []int32:
 		list := arr.list.([]int32)
 		otherArr, ok := other.list.([]int32)
-		if !ok {
-			return nil, ErrListsNotOfSameType
+		err := validateListSum(ok, arr.Len(), other.Len())
+		if err != nil {
+			return &List{}, err
 		}
 		sum := core.ListSumInt32(list, otherArr)
 		return NewList(sum), nil
@@ -27,8 +42,9 @@ func (arr *List) ListSum(other *List) (*List, error) {
 	case []int64:
 		list := arr.list.([]int64)
 		otherArr, ok := other.list.([]int64)
-		if !ok {
-			return nil, ErrListsNotOfSameType
+		err := validateListSum(ok, arr.Len(), other.Len())
+		if err != nil {
+			return &List{}, err
 		}
 		sum := core.ListSumInt64(list, otherArr)
 		return NewList(sum), nil
@@ -36,8 +52,9 @@ func (arr *List) ListSum(other *List) (*List, error) {
 	case []float32:
 		list := arr.list.([]float32)
 		otherArr, ok := other.list.([]float32)
-		if !ok {
-			return nil, ErrListsNotOfSameType
+		err := validateListSum(ok, arr.Len(), other.Len())
+		if err != nil {
+			return &List{}, err
 		}
 		sum := core.ListSumFloat32(list, otherArr)
 		return NewList(sum), nil
@@ -45,17 +62,18 @@ func (arr *List) ListSum(other *List) (*List, error) {
 	case []float64:
 		list := arr.list.([]float64)
 		otherArr, ok := other.list.([]float64)
-		if !ok {
-			return nil, ErrListsNotOfSameType
+		err := validateListSum(ok, arr.Len(), other.Len())
+		if err != nil {
+			return &List{}, err
 		}
 		sum := core.ListSumFloat64(list, otherArr)
 		return NewList(sum), nil
 
 	case []string:
-		return nil, ErrStringsNotsupported
+		return &List{}, ErrStringsNotsupported
 
 	default:
-		return nil, ErrTypeNotsupported
+		return &List{}, ErrTypeNotsupported
 	}
 
 }

--- a/README.md
+++ b/README.md
@@ -340,3 +340,12 @@ if err != nil {
 }
 fmt.Println(newList) // [1, 0, 1, 0, 2, 0]
 ```
+
+## list.ListSum(other *golist.List) (golist.List, err)
+Add the content of two lists. The lists must be of the same type and have equal length. Example:
+```golang
+list1 := golist.NewList([]int{1,1})
+list2 := golist.NewList([]int{2,2})
+list3 := list1.SumList(list2)
+fmt.Println(list3) // [3,3]
+```

--- a/core/float32list.go
+++ b/core/float32list.go
@@ -181,3 +181,11 @@ func SetFloat32(list []float32) (set []float32) {
 	}
 	return
 }
+
+// ListSumInt sums contents of two lists
+func ListSumFloat32(list []float32, other []float32) (sum []float32) {
+	for i, v := range list {
+		sum = append(sum, v+other[i])
+	}
+	return
+}

--- a/core/floatlist64.go
+++ b/core/floatlist64.go
@@ -222,3 +222,11 @@ func SetFloat64(list []float64) (set []float64) {
 	}
 	return
 }
+
+// ListSumInt sums contents of two lists
+func ListSumFloat64(list []float64, other []float64) (sum []float64) {
+	for i, v := range list {
+		sum = append(sum, v+other[i])
+	}
+	return
+}

--- a/core/int32list.go
+++ b/core/int32list.go
@@ -209,3 +209,11 @@ func SetInt32(list []int32) (set []int32) {
 	}
 	return
 }
+
+// ListSumInt sums contents of two lists
+func ListSumInt32(list []int32, other []int32) (sum []int32) {
+	for i, v := range list {
+		sum = append(sum, v+other[i])
+	}
+	return
+}

--- a/core/int64list.go
+++ b/core/int64list.go
@@ -209,3 +209,11 @@ func SetInt64(list []int64) (set []int64) {
 	}
 	return
 }
+
+// ListSumInt64 sums contents of two lists
+func ListSumInt64(list []int64, other []int64) (sum []int64) {
+	for i, v := range list {
+		sum = append(sum, v+other[i])
+	}
+	return
+}

--- a/core/intlist.go
+++ b/core/intlist.go
@@ -208,3 +208,11 @@ func SetInt(list []int) (set []int) {
 	}
 	return
 }
+
+// ListSumInt sums contents of two lists
+func ListSumInt(list []int, other []int) (sum []int) {
+	for i, v := range list {
+		sum = append(sum, v+other[i])
+	}
+	return
+}

--- a/errors.go
+++ b/errors.go
@@ -8,4 +8,5 @@ var (
 	ErrStringsNotsupported = errors.New("operation error: strings are not supported for this operation")
 	ErrIndexOutOfRange     = errors.New("index error: list index out of range")
 	ErrListsNotOfSameType  = errors.New("type error: lists not of same type")
+	ErrListsNotOfSameLen   = errors.New("length error: lists not of same length")
 )

--- a/more_test.go
+++ b/more_test.go
@@ -198,12 +198,8 @@ func TestReverse(t *testing.T) {
 	for _, tC := range testCases {
 		got := tC.Obj.Reverse()
 
-		for i := 0; i < got.Len(); i++ {
-			Gotitem := got.Get(i)
-			Expecteditem := tC.expected.Get(i)
-			if Gotitem != Expecteditem {
-				t.Errorf("Error [TestReverse] Got: %v Expected: %v \n.", got, tC.expected)
-			}
+		if !got.IsEqual(&tC.expected) {
+			t.Errorf("Error [TestReverse] Got: %v Expected: %v \n.", got, &tC.expected)
 		}
 
 	}
@@ -600,6 +596,64 @@ func TestType(t *testing.T) {
 		got := tC.Obj.Type()
 		if got != tC.expected {
 			t.Errorf("Type Error : %v != %v", tC.expected, got)
+		}
+
+	}
+}
+
+func TestListSum(t *testing.T) {
+	testCases := []struct {
+		Obj      *List
+		other    *List
+		Error    error
+		expected *List
+	}{
+		{
+			Obj:      NewList([]int{2, 3, 4}),
+			other:    NewList([]int{1, 1, 1}),
+			Error:    nil,
+			expected: NewList([]int{3, 4, 5}),
+		},
+		{
+			Obj:      NewList([]int32{2, 3, 4}),
+			other:    NewList([]int32{1, 1, 1}),
+			Error:    nil,
+			expected: NewList([]int32{3, 4, 5}),
+		},
+		{
+			Obj:      NewList([]int64{2, 3, 4}),
+			other:    NewList([]int64{1, 1, 1}),
+			Error:    nil,
+			expected: NewList([]int64{3, 4, 5}),
+		},
+		{
+			Obj:      NewList([]float32{2, 3, 4}),
+			other:    NewList([]float32{1, 1, 1}),
+			Error:    nil,
+			expected: NewList([]float32{3, 4, 5}),
+		},
+		{
+			Obj:      NewList([]float64{2, 3, 4}),
+			other:    NewList([]float64{1, 1, 1}),
+			Error:    nil,
+			expected: NewList([]float64{3, 4, 5}),
+		},
+		// edge cases
+		{
+			Obj:      NewList([]float64{2, 3, 4}),
+			other:    NewList([]float64{1, 1, 1, 2}),
+			Error:    ErrListsNotOfSameLen,
+			expected: &List{},
+		},
+	}
+	for _, tC := range testCases {
+		got, err := tC.Obj.ListSum(tC.other)
+		if err != tC.Error {
+			t.Errorf("Errors Not same ListSum: Got: %v Expected: %v \n", err, tC.Error)
+		}
+
+		if !got.IsEqual(tC.expected) {
+			t.Errorf("Error [TestListSum] Got: %v Expected: %v \n.", got, tC.expected)
 		}
 
 	}


### PR DESCRIPTION
## list.ListSum(other *golist.List) (golist.List, err)
Add the content of two lists. The lists must be of the same type and have equal length. Example:
```golang
list1 := golist.NewList([]int{1,1})
list2 := golist.NewList([]int{2,2})
list3 := list1.SumList(list2)
fmt.Println(list3) // [3,3]
```

resolves #83 