### PR TITLE
convertTo [#92]

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,11 +341,20 @@ if err != nil {
 fmt.Println(newList) // [1, 0, 1, 0, 2, 0]
 ```
 
-## list.ListSum(other *golist.List) (golist.List, err)
+## list.ListSum(other *golist.List) (*golist.List, err)
 Add the content of two lists. The lists must be of the same type and have equal length. Example:
 ```golang
 list1 := golist.NewList([]int{1,1})
 list2 := golist.NewList([]int{2,2})
 list3 := list1.SumList(list2)
 fmt.Println(list3) // [3,3]
+```
+
+## list.ConvertTo(t golist.ListType) (*golist.List, err)
+converts list from type `a` to type `b`. Example
+```golang
+list := golist.NewList([]int{1,1})
+fmt.Println(list.Type()) // golist.List[]int
+list.ConvertTo(golist.TypeListInt32)
+fmt.Println(list.Type()) // golist.List[]int32
 ```

--- a/core/common.go
+++ b/core/common.go
@@ -9,4 +9,5 @@ var (
 	ErrNotZeroOrPositive = errors.New("numbers must be zero or positive")
 	ErrNotInList         = errors.New("element not in list")
 	ErrListEmpty         = errors.New("list is empty")
+	ErrTypeNotSupported  = errors.New("type not supported")
 )

--- a/core/float32list.go
+++ b/core/float32list.go
@@ -189,3 +189,40 @@ func ListSumFloat32(list []float32, other []float32) (sum []float32) {
 	}
 	return
 }
+
+// ConvertToFloat32 converts to slice to float32
+func ConvertToFloat32(array interface{}) (Intify []float32, err error) {
+
+	switch array := array.(type) {
+	case []int:
+		for _, v := range array {
+			Intify = append(Intify, float32(v))
+		}
+
+	case []int32:
+		for _, v := range array {
+			Intify = append(Intify, float32(v))
+		}
+
+	case []int64:
+		for _, v := range array {
+			Intify = append(Intify, float32(v))
+		}
+
+	case []float32:
+		return array, nil
+
+	case []float64:
+		for _, v := range array {
+			Intify = append(Intify, float32(v))
+		}
+
+	case []string:
+		return nil, ErrTypeNotSupported
+
+	default:
+		return nil, ErrTypeNotSupported
+
+	}
+	return
+}

--- a/core/floatlist64.go
+++ b/core/floatlist64.go
@@ -230,3 +230,40 @@ func ListSumFloat64(list []float64, other []float64) (sum []float64) {
 	}
 	return
 }
+
+// ConvertToFloat64 converts to slice to float64
+func ConvertToFloat64(array interface{}) (Intify []float64, err error) {
+
+	switch array := array.(type) {
+	case []int:
+		for _, v := range array {
+			Intify = append(Intify, float64(v))
+		}
+
+	case []int32:
+		for _, v := range array {
+			Intify = append(Intify, float64(v))
+		}
+
+	case []int64:
+		for _, v := range array {
+			Intify = append(Intify, float64(v))
+		}
+
+	case []float32:
+		for _, v := range array {
+			Intify = append(Intify, float64(v))
+		}
+
+	case []float64:
+		return array, nil
+
+	case []string:
+		return nil, ErrTypeNotSupported
+
+	default:
+		return nil, ErrTypeNotSupported
+
+	}
+	return
+}

--- a/core/int32list.go
+++ b/core/int32list.go
@@ -217,3 +217,40 @@ func ListSumInt32(list []int32, other []int32) (sum []int32) {
 	}
 	return
 }
+
+// ConvertToInt32 converts to slice to int32
+func ConvertToInt32(array interface{}) (Intify []int32, err error) {
+
+	switch array := array.(type) {
+	case []int:
+		for _, v := range array {
+			Intify = append(Intify, int32(v))
+		}
+
+	case []int32:
+		return array, nil
+
+	case []int64:
+		for _, v := range array {
+			Intify = append(Intify, int32(v))
+		}
+
+	case []float32:
+		for _, v := range array {
+			Intify = append(Intify, int32(v))
+		}
+
+	case []float64:
+		for _, v := range array {
+			Intify = append(Intify, int32(v))
+		}
+
+	case []string:
+		return nil, ErrTypeNotSupported
+
+	default:
+		return nil, ErrTypeNotSupported
+
+	}
+	return
+}

--- a/core/int64list.go
+++ b/core/int64list.go
@@ -217,3 +217,40 @@ func ListSumInt64(list []int64, other []int64) (sum []int64) {
 	}
 	return
 }
+
+// ConvertToInt64 converts to slice to int64
+func ConvertToInt64(array interface{}) (Intify []int64, err error) {
+
+	switch array := array.(type) {
+	case []int:
+		for _, v := range array {
+			Intify = append(Intify, int64(v))
+		}
+
+	case []int32:
+		for _, v := range array {
+			Intify = append(Intify, int64(v))
+		}
+
+	case []int64:
+		return array, nil
+
+	case []float32:
+		for _, v := range array {
+			Intify = append(Intify, int64(v))
+		}
+
+	case []float64:
+		for _, v := range array {
+			Intify = append(Intify, int64(v))
+		}
+
+	case []string:
+		return nil, ErrTypeNotSupported
+
+	default:
+		return nil, ErrTypeNotSupported
+
+	}
+	return
+}

--- a/core/intlist.go
+++ b/core/intlist.go
@@ -216,3 +216,40 @@ func ListSumInt(list []int, other []int) (sum []int) {
 	}
 	return
 }
+
+// ConvertToInt converts to slice to int
+func ConvertToInt(array interface{}) (Intify []int, err error) {
+
+	switch array := array.(type) {
+	case []int:
+		return array, nil
+
+	case []int32:
+		for _, v := range array {
+			Intify = append(Intify, int(v))
+		}
+
+	case []int64:
+		for _, v := range array {
+			Intify = append(Intify, int(v))
+		}
+
+	case []float32:
+		for _, v := range array {
+			Intify = append(Intify, int(v))
+		}
+
+	case []float64:
+		for _, v := range array {
+			Intify = append(Intify, int(v))
+		}
+
+	case []string:
+		return nil, ErrTypeNotSupported
+
+	default:
+		return nil, ErrTypeNotSupported
+
+	}
+	return
+}

--- a/core/stringlist.go
+++ b/core/stringlist.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"fmt"
 	"math/bits"
 	"sort"
 	"strings"
@@ -215,6 +216,44 @@ func SetString(list []string) (set []string) {
 			keys[key] = true
 			set = append(set, key)
 		}
+	}
+	return
+}
+
+func ConvertToString(array interface{}) (stringfy []string, err error) {
+
+	switch array := array.(type) {
+	case []int:
+		for _, v := range array {
+			stringfy = append(stringfy, fmt.Sprintf("%v", v))
+		}
+
+	case []int32:
+		for _, v := range array {
+			stringfy = append(stringfy, fmt.Sprintf("%v", v))
+		}
+
+	case []int64:
+		for _, v := range array {
+			stringfy = append(stringfy, fmt.Sprintf("%v", v))
+		}
+
+	case []float32:
+		for _, v := range array {
+			stringfy = append(stringfy, fmt.Sprintf("%v", v))
+		}
+
+	case []float64:
+		for _, v := range array {
+			stringfy = append(stringfy, fmt.Sprintf("%v", v))
+		}
+
+	case []string:
+		return array, nil
+
+	default:
+		return nil, ErrTypeNotSupported
+
 	}
 	return
 }

--- a/more_test.go
+++ b/more_test.go
@@ -594,7 +594,7 @@ func TestType(t *testing.T) {
 	}
 	for _, tC := range testCases {
 		got := tC.Obj.Type()
-		if got != tC.expected {
+		if got != ListType(tC.expected) {
 			t.Errorf("Type Error : %v != %v", tC.expected, got)
 		}
 
@@ -654,6 +654,61 @@ func TestListSum(t *testing.T) {
 
 		if !got.IsEqual(tC.expected) {
 			t.Errorf("Error [TestListSum] Got: %v Expected: %v \n.", got, tC.expected)
+		}
+
+	}
+}
+
+func TestConvertTo(t *testing.T) {
+
+	testCases := []struct {
+		Obj      *List
+		expected *List
+		itype    ListType
+	}{
+		{
+			Obj:      NewList([]int{10, 5, 25, 200}),
+			expected: NewList([]float32{10, 5, 25, 200}),
+			itype:    TypeListFloat32,
+		},
+		{
+			Obj:      NewList([]int32{10, 5, 25, 200}),
+			expected: NewList([]float64{10, 5, 25, 200}),
+			itype:    TypeListFloat64,
+		},
+		{
+			Obj:      NewList([]int64{10, 5, 25, 200}),
+			expected: NewList([]int{10, 5, 25, 200}),
+			itype:    TypeListInt,
+		},
+		{
+			Obj:      NewList([]float32{10, 5, 25, 200}),
+			expected: NewList([]int32{10, 5, 25, 200}),
+			itype:    TypeListInt32,
+		},
+		{
+			Obj:      NewList([]float64{10, 5, 25, 200}),
+			expected: NewList([]int64{10, 5, 25, 200}),
+			itype:    TypeListInt64,
+		},
+		{
+			Obj:      NewList([]float64{10, 5, 25, 200}),
+			expected: NewList([]string{"10", "5", "25", "200"}),
+			itype:    TypeListString,
+		},
+		{
+			Obj:      NewList([]string{"Hello", "world"}),
+			expected: NewList([]string{"Hello", "world"}),
+			itype:    TypeListString,
+		},
+	}
+	for _, tC := range testCases {
+		got, err := tC.Obj.ConvertTo(tC.itype)
+		if err != nil {
+			t.Errorf("Convert Error : %v", err)
+		}
+		if got.Type() != tC.expected.Type() {
+			t.Errorf("Type Error : %v != %v", tC.expected.Type(), got.Type())
 		}
 
 	}

--- a/type.go
+++ b/type.go
@@ -1,18 +1,22 @@
 package golist
 
+import "github.com/emylincon/golist/core"
+
 // List types
 const (
-	TypeListInt     = "golist.List[]int"
-	TypeListInt32   = "golist.List[]int32"
-	TypeListInt64   = "golist.List[]int64"
-	TypeListFloat32 = "golist.List[]float32"
-	TypeListFloat64 = "golist.List[]float64"
-	TypeListString  = "golist.List[]string"
-	TypeListUnknown = "golist.List[]unknown"
+	TypeListInt     ListType = "golist.List[]int"
+	TypeListInt32   ListType = "golist.List[]int32"
+	TypeListInt64   ListType = "golist.List[]int64"
+	TypeListFloat32 ListType = "golist.List[]float32"
+	TypeListFloat64 ListType = "golist.List[]float64"
+	TypeListString  ListType = "golist.List[]string"
+	TypeListUnknown ListType = "golist.List[]unknown"
 )
 
-// Type: returns string representation of the list.
-func (arr *List) Type() (ltype string) {
+type ListType string
+
+// Type returns string representation of the list.
+func (arr *List) Type() ListType {
 	switch arr.list.(type) {
 	case []int:
 		return TypeListInt
@@ -34,5 +38,55 @@ func (arr *List) Type() (ltype string) {
 
 	default:
 		return TypeListUnknown
+	}
+}
+
+// ConvertTo converts list to a new type
+func (arr *List) ConvertTo(t ListType) (*List, error) {
+	switch t {
+	case TypeListInt:
+		list, err := core.ConvertToInt(arr.list)
+		if err != nil {
+			return &List{}, err
+		}
+		return NewList(list), nil
+
+	case TypeListInt32:
+		list, err := core.ConvertToInt32(arr.list)
+		if err != nil {
+			return &List{}, err
+		}
+		return NewList(list), nil
+
+	case TypeListInt64:
+		list, err := core.ConvertToInt64(arr.list)
+		if err != nil {
+			return &List{}, err
+		}
+		return NewList(list), nil
+
+	case TypeListFloat32:
+		list, err := core.ConvertToFloat32(arr.list)
+		if err != nil {
+			return &List{}, err
+		}
+		return NewList(list), nil
+
+	case TypeListFloat64:
+		list, err := core.ConvertToFloat64(arr.list)
+		if err != nil {
+			return &List{}, err
+		}
+		return NewList(list), nil
+
+	case TypeListString:
+		list, err := core.ConvertToString(arr.list)
+		if err != nil {
+			return &List{}, err
+		}
+		return NewList(list), nil
+
+	default:
+		return &List{}, ErrTypeNotsupported
 	}
 }


### PR DESCRIPTION
## list.ConvertTo(t golist.ListType) (*golist.List, err)
converts list from type `a` to type `b`. Example
```golang
list := golist.NewList([]int{1,1})
fmt.Println(list.Type()) // golist.List[]int
list.ConvertTo(golist.TypeListInt32)
fmt.Println(list.Type()) // golist.List[]int32
```

closes #92 