### PR TITLE
list divide

### DIFF
--- a/ListDivide.go
+++ b/ListDivide.go
@@ -1,0 +1,126 @@
+package golist
+
+import (
+	"github.com/emylincon/golist/core"
+)
+
+// ListDivide divides list with other list
+func (arr *List) ListDivide(other *List) (*List, error) {
+
+	switch arr.list.(type) {
+	case []int:
+		list := arr.list.([]int)
+		otherArr, ok := other.list.([]int)
+		err := validateListOp(ok, arr.Len(), other.Len())
+		if err != nil {
+			return &List{}, err
+		}
+		sum := core.ListDivideInt(list, otherArr)
+		return NewList(sum), nil
+
+	case []int32:
+		list := arr.list.([]int32)
+		otherArr, ok := other.list.([]int32)
+		err := validateListOp(ok, arr.Len(), other.Len())
+		if err != nil {
+			return &List{}, err
+		}
+		sum := core.ListDivideInt32(list, otherArr)
+		return NewList(sum), nil
+
+	case []int64:
+		list := arr.list.([]int64)
+		otherArr, ok := other.list.([]int64)
+		err := validateListOp(ok, arr.Len(), other.Len())
+		if err != nil {
+			return &List{}, err
+		}
+		sum := core.ListDivideInt64(list, otherArr)
+		return NewList(sum), nil
+
+	case []float32:
+		list := arr.list.([]float32)
+		otherArr, ok := other.list.([]float32)
+		err := validateListOp(ok, arr.Len(), other.Len())
+		if err != nil {
+			return &List{}, err
+		}
+		sum := core.ListDivideFloat32(list, otherArr)
+		return NewList(sum), nil
+
+	case []float64:
+		list := arr.list.([]float64)
+		otherArr, ok := other.list.([]float64)
+		err := validateListOp(ok, arr.Len(), other.Len())
+		if err != nil {
+			return &List{}, err
+		}
+		sum := core.ListDivideFloat64(list, otherArr)
+		return NewList(sum), nil
+
+	case []string:
+		return &List{}, ErrStringsNotsupported
+
+	default:
+		return &List{}, ErrTypeNotsupported
+	}
+
+}
+
+// ListDivideNo Divide all elements in list with a number
+func (arr *List) ListDivideNo(no interface{}) (*List, error) {
+
+	switch arr.list.(type) {
+	case []int:
+		list := arr.list.([]int)
+		o, ok := no.(int)
+		if !ok {
+			return &List{}, ErrTypeNotSame
+		}
+		sum := core.ListDivideNoInt(list, o)
+		return NewList(sum), nil
+
+	case []int32:
+		list := arr.list.([]int32)
+		o, ok := no.(int32)
+		if !ok {
+			return &List{}, ErrTypeNotSame
+		}
+		sum := core.ListDivideNoInt32(list, o)
+		return NewList(sum), nil
+
+	case []int64:
+		list := arr.list.([]int64)
+		o, ok := no.(int64)
+		if !ok {
+			return &List{}, ErrTypeNotSame
+		}
+		sum := core.ListDivideNoInt64(list, o)
+		return NewList(sum), nil
+
+	case []float32:
+		list := arr.list.([]float32)
+		o, ok := no.(float32)
+		if !ok {
+			return &List{}, ErrTypeNotSame
+		}
+		sum := core.ListDivideNoFloat32(list, o)
+		return NewList(sum), nil
+
+	case []float64:
+		list := arr.list.([]float64)
+		o, ok := no.(float64)
+		if !ok {
+			return &List{}, ErrTypeNotSame
+		}
+		sum := core.ListDivideNoFloat64(list, o)
+		return NewList(sum), nil
+
+	case []string:
+		return &List{}, ErrStringsNotsupported
+
+	default:
+		return &List{}, ErrTypeNotsupported
+	}
+
+}

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ fmt.Println(index)  // 1
 ## `list.String()`
 Returns a string representation of the object
 ```golang
-list := NewList([]int{3,2,1})
+list := golist.NewList([]int{3,2,1})
 fmt.Println(list.String())  // [3, 2, 1]
 ```
 
@@ -317,7 +317,7 @@ Furthermore `NewList([]string{"a", "b", "c"}).Combinations(2, "") = ["ab", "ac",
 * For `n < 1`, it equals to All and returns all combinations.
 * For `n > len(list)` then `n = len(list)`
 ```golang
-list := NewList([]string{"a", "b", "c"})
+list := golist.NewList([]string{"a", "b", "c"})
 combinedList := list.Combinations(2, " ")
 fmt.Println(combinedList)  // ["a b", "a c", "b c"]
 combinedList = list.Combinations(2, ",")
@@ -369,7 +369,7 @@ fmt.Println(list3) // [3,3]
 ## `list.ListSumNo(no interface{}) (*golist.List, err)`
 Add number to all elements in list. Example
 ```golang
-list1 := NewList([]int{1,1})
+list1 := golist.NewList([]int{1,1})
 no := 2
 list3 := list1.ListSumNo(no)
 fmt.Println(list3) // [3,3]
@@ -399,7 +399,7 @@ fmt.Println(list3) // [-1, -1]
 ## `list.ListSubtractNo(no interface{}) (*golist.List, err)`
 Subtract number from all elements in list. Example
 ```golang
-list1 := NewList([]int{1,1})
+list1 := golist.NewList([]int{1,1})
 var no int = 2
 list3, err := list1.ListSubtractNo(no)
 if err != nil {
@@ -423,11 +423,35 @@ fmt.Println(list3) // [2, 2]
 ## `list.ListMultiplyNo(no interface{}) (*golist.List, err)`
 Multiply a number with all elements in list. Example
 ```golang
-list1 := NewList([]int{1,1})
+list1 := golist.NewList([]int{1,1})
 var no int = 2
 list3, err := list1.ListMultiplyNo(no)
 if err != nil {
     fmt.Println(err) // handle error
 }
 fmt.Println(list3) // [2, 2]
+```
+
+## `list.ListDivide(other *golist.List) (*golist.List, err)`
+Divide the content of two lists. The lists must be of the same type and have equal length. Example:
+```golang
+list1 := golist.NewList([]int{8,6})
+list2 := golist.NewList([]int{2,2})
+list3, err := list1.ListDivide(list2)
+if err != nil {
+    fmt.Println(err) // handle error
+}
+fmt.Println(list3) // [4, 3]
+```
+
+## `list.ListDivideNo(no interface{}) (*golist.List, err)`
+Divide all elements in list with no. Example
+```golang
+list1 := golist.NewList([]int{12,2})
+var no int = 2
+list3, err := list1.ListDivideNo(no)
+if err != nil {
+    fmt.Println(err) // handle error
+}
+fmt.Println(list3) // [6, 1]
 ```

--- a/core/float32list.go
+++ b/core/float32list.go
@@ -230,6 +230,22 @@ func ListMultiplyNoFloat32(list []float32, no float32) (product []float32) {
 	return
 }
 
+// ListDivideFloat32 divide the contents of two lists
+func ListDivideFloat32(list []float32, other []float32) (product []float32) {
+	for i, v := range list {
+		product = append(product, v/other[i])
+	}
+	return
+}
+
+// ListMultiplyNoFloat32 divide a given number with all elements in list
+func ListDivideNoFloat32(list []float32, no float32) (product []float32) {
+	for _, v := range list {
+		product = append(product, v/no)
+	}
+	return
+}
+
 // ConvertToFloat32 converts to slice to float32
 func ConvertToFloat32(array interface{}) (Intify []float32, err error) {
 

--- a/core/floatlist64.go
+++ b/core/floatlist64.go
@@ -271,6 +271,22 @@ func ListMultiplyNoFloat64(list []float64, no float64) (product []float64) {
 	return
 }
 
+// ListDivideFloat64 divide the contents of two lists
+func ListDivideFloat64(list []float64, other []float64) (product []float64) {
+	for i, v := range list {
+		product = append(product, v/other[i])
+	}
+	return
+}
+
+// ListMultiplyNoFloat64 divide a given number with all elements in list
+func ListDivideNoFloat64(list []float64, no float64) (product []float64) {
+	for _, v := range list {
+		product = append(product, v/no)
+	}
+	return
+}
+
 // ConvertToFloat64 converts to slice to float64
 func ConvertToFloat64(array interface{}) (Intify []float64, err error) {
 

--- a/core/int32list.go
+++ b/core/int32list.go
@@ -258,6 +258,22 @@ func ListMultiplyNoInt32(list []int32, no int32) (product []int32) {
 	return
 }
 
+// ListDivideInt32 divide the contents of two lists
+func ListDivideInt32(list []int32, other []int32) (product []int32) {
+	for i, v := range list {
+		product = append(product, v/other[i])
+	}
+	return
+}
+
+// ListMultiplyNoInt32 divide a given number with all elements in list
+func ListDivideNoInt32(list []int32, no int32) (product []int32) {
+	for _, v := range list {
+		product = append(product, v/no)
+	}
+	return
+}
+
 // ConvertToInt32 converts to slice to int32
 func ConvertToInt32(array interface{}) (Intify []int32, err error) {
 

--- a/core/int64list.go
+++ b/core/int64list.go
@@ -258,6 +258,22 @@ func ListMultiplyNoInt64(list []int64, no int64) (product []int64) {
 	return
 }
 
+// ListDivideInt64 divide the contents of two lists
+func ListDivideInt64(list []int64, other []int64) (product []int64) {
+	for i, v := range list {
+		product = append(product, v/other[i])
+	}
+	return
+}
+
+// ListMultiplyNoInt64 divide a given number with all elements in list
+func ListDivideNoInt64(list []int64, no int64) (product []int64) {
+	for _, v := range list {
+		product = append(product, v/no)
+	}
+	return
+}
+
 // ConvertToInt64 converts to slice to int64
 func ConvertToInt64(array interface{}) (Intify []int64, err error) {
 

--- a/core/intlist.go
+++ b/core/intlist.go
@@ -257,6 +257,22 @@ func ListMultiplyNoInt(list []int, no int) (product []int) {
 	return
 }
 
+// ListDivideInt divide the contents of two lists
+func ListDivideInt(list []int, other []int) (product []int) {
+	for i, v := range list {
+		product = append(product, v/other[i])
+	}
+	return
+}
+
+// ListMultiplyNoInt divide a given number with all elements in list
+func ListDivideNoInt(list []int, no int) (product []int) {
+	for _, v := range list {
+		product = append(product, v/no)
+	}
+	return
+}
+
 // ConvertToInt converts to slice to int
 func ConvertToInt(array interface{}) (Intify []int, err error) {
 

--- a/example_list_test.go
+++ b/example_list_test.go
@@ -50,6 +50,7 @@ func Example() {
 	}
 	fmt.Println("ListSubtract :", list3)
 
+	// Multiply all elements in list with no. Example
 	list1 = golist.NewList([]int{1, 1})
 	var no int = 2
 	list3, err = list1.ListMultiplyNo(no)
@@ -57,6 +58,15 @@ func Example() {
 		fmt.Println(err) // handle error
 	}
 	fmt.Println("ListMultiplyNo :", list3)
+
+	// Divide all elements with other list. Example
+	list1 = golist.NewList([]int{8, 6})
+	list2 = golist.NewList([]int{2, 2})
+	list3, err = list1.ListDivide(list2)
+	if err != nil {
+		fmt.Println(err) // handle error
+	}
+	fmt.Println("ListDivide :", list3)
 
 	// Output:
 	// Get(0) : 1
@@ -68,4 +78,5 @@ func Example() {
 	// Remove(7) : [1, 2, 3, 4, 5]
 	// ListSubtract : [-1, -1]
 	// ListMultiplyNo : [2, 2]
+	// ListDivide : [4, 3]
 }

--- a/more_test.go
+++ b/more_test.go
@@ -812,3 +812,98 @@ func TestListMultiplyNo(t *testing.T) {
 
 	}
 }
+
+func TestListDivide(t *testing.T) {
+
+	testCases := []struct {
+		Obj      *golist.List
+		other    *golist.List
+		expected *golist.List
+	}{
+		{
+			Obj:      golist.NewList([]int{4, 15}),
+			other:    golist.NewList([]int{2, 5}),
+			expected: golist.NewList([]int{2, 3}),
+		},
+		{
+			Obj:      golist.NewList([]int32{4, 15}),
+			other:    golist.NewList([]int32{2, 5}),
+			expected: golist.NewList([]int32{2, 3}),
+		},
+		{
+			Obj:      golist.NewList([]int64{4, 15}),
+			other:    golist.NewList([]int64{2, 5}),
+			expected: golist.NewList([]int64{2, 3}),
+		},
+		{
+			Obj:      golist.NewList([]float32{4, 15}),
+			other:    golist.NewList([]float32{2, 5}),
+			expected: golist.NewList([]float32{2, 3}),
+		},
+		{
+			Obj:      golist.NewList([]float64{4, 15}),
+			other:    golist.NewList([]float64{2, 5}),
+			expected: golist.NewList([]float64{2, 3}),
+		},
+	}
+	for _, tC := range testCases {
+		got, err := tC.Obj.ListDivide(tC.other)
+		if err != nil {
+			t.Errorf("[Error TestListDivide]: %v", err)
+		}
+
+		if !got.IsEqual(tC.expected) {
+			t.Errorf("[Error TestListDivide] : Got: %v, Expected: %v. Type: %v\n", got, tC.expected, tC.expected.Type())
+		}
+	}
+}
+
+func TestListDivideNo(t *testing.T) {
+	var vint int = 5
+	var vint32 int32 = 5
+	var vint64 int64 = 5
+	var vfloat32 float32 = 5
+	var vfloat64 float64 = 5
+
+	testCases := []struct {
+		expected golist.List
+		obj      golist.List
+		no       interface{}
+	}{
+		{
+			expected: *golist.NewList([]int{2, 3, 4}),
+			obj:      *golist.NewList([]int{10, 15, 20}),
+			no:       vint,
+		},
+		{
+			expected: *golist.NewList([]int32{2, 3, 4}),
+			obj:      *golist.NewList([]int32{10, 15, 20}),
+			no:       vint32,
+		},
+		{
+			expected: *golist.NewList([]int64{2, 3, 4}),
+			obj:      *golist.NewList([]int64{10, 15, 20}),
+			no:       vint64,
+		},
+		{
+			expected: *golist.NewList([]float32{2, 3, 4}),
+			obj:      *golist.NewList([]float32{10, 15, 20}),
+			no:       vfloat32,
+		},
+		{
+			expected: *golist.NewList([]float64{2, 3, 4}),
+			obj:      *golist.NewList([]float64{10, 15, 20}),
+			no:       vfloat64,
+		},
+	}
+	for _, tC := range testCases {
+		got, err := tC.obj.ListDivideNo(tC.no)
+		if err != nil {
+			t.Errorf("[Error DivideListNo] : %v", err)
+		}
+		if !got.IsEqual(&tC.expected) {
+			t.Errorf("[Error DivideListNo] : Got: %v, Expected: %v.\n", got, &tC.expected)
+		}
+
+	}
+}


### PR DESCRIPTION
## `list.ListDivide(other *golist.List) (*golist.List, err)`
Divide the content of two lists. The lists must be of the same type and have equal length. Example:
```golang
list1 := golist.NewList([]int{8,6})
list2 := golist.NewList([]int{2,2})
list3, err := list1.ListDivide(list2)
if err != nil {
    fmt.Println(err) // handle error
}
fmt.Println(list3) // [4, 3]
```

## `list.ListDivideNo(no interface{}) (*golist.List, err)`
Divide all elements in list with no. Example
```golang
list1 := golist.NewList([]int{12,2})
var no int = 2
list3, err := list1.ListDivideNo(no)
if err != nil {
    fmt.Println(err) // handle error
}
fmt.Println(list3) // [6, 1]
```

closes #105 
closes #90 