### PR TITLE
convert golist to slice implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -460,3 +460,75 @@ if err != nil {
 }
 fmt.Println(list3) // [6, 1]
 ```
+
+## `list.ConvertToSliceFloat32() ([]float32, error)`
+Converts golist to []float32. Example
+```golang
+list := golist.NewList([]int{12,2})
+
+slice, err := list.ConvertToSliceFloat32()
+if err != nil {
+    fmt.Println(err) // handle error
+}
+fmt.Printf("%T", slice) // []float32
+```
+
+## `list.ConvertToSliceFloat64() ([]float64, error)`
+Converts golist to []float64. Example
+```golang
+list := golist.NewList([]int{12,2})
+
+slice, err := list.ConvertToSliceFloat64()
+if err != nil {
+    fmt.Println(err) // handle error
+}
+fmt.Printf("%T", slice) // []float64
+```
+
+## `list.ConvertToSliceInt64() ([]int64, error)`
+Converts golist to []int64. Example
+```golang
+list := golist.NewList([]int{12,2})
+
+slice, err := list.ConvertToSliceInt64()
+if err != nil {
+    fmt.Println(err) // handle error
+}
+fmt.Printf("%T", slice) // []int64
+```
+
+## `list.ConvertToSliceInt32() ([]int32, error)`
+Converts golist to []int32. Example
+```golang
+list := golist.NewList([]int{12,2})
+
+slice, err := list.ConvertToSliceInt32()
+if err != nil {
+    fmt.Println(err) // handle error
+}
+fmt.Printf("%T", slice) // []int32
+```
+
+## `list.ConvertToSliceInt() ([]int, error)`
+Converts golist to []int. Example
+```golang
+list := golist.NewList([]int{12,2})
+
+slice, err := list.ConvertToSliceInt()
+if err != nil {
+    fmt.Println(err) // handle error
+}
+fmt.Printf("%T", slice) // []int
+```
+
+## `list.ConvertToSliceString() ([]string, error)`
+Converts golist to []string. Example
+```golang
+list := golist.NewList([]int{12,2})
+
+slice, err := list.ConvertToSliceString()
+if err != nil {
+    fmt.Println(err) // handle error
+}
+fmt.Printf("%T", slice) // []string
+```

--- a/example_list_test.go
+++ b/example_list_test.go
@@ -68,6 +68,13 @@ func Example() {
 	}
 	fmt.Println("ListDivide :", list3)
 
+	// convert list to slice of strings
+	slice, err := list.ConvertToSliceString()
+	if err != nil {
+		fmt.Println(err) // handle error
+	}
+	fmt.Printf("%T\n", slice)
+
 	// Output:
 	// Get(0) : 1
 	// Index(2) : 1
@@ -79,4 +86,5 @@ func Example() {
 	// ListSubtract : [-1, -1]
 	// ListMultiplyNo : [2, 2]
 	// ListDivide : [4, 3]
+	// []string
 }

--- a/list_test.go
+++ b/list_test.go
@@ -872,3 +872,85 @@ func TestListSubtractNo(t *testing.T) {
 
 	}
 }
+
+func TestConvertToSlice(t *testing.T) {
+	testCases := []struct {
+		Obj      *golist.List
+		expected *golist.List
+		desc     string
+	}{
+		{
+			Obj:      golist.NewList([]int{10, 5, 25, 200}),
+			expected: golist.NewList([]float32{10, 5, 25, 200}),
+			desc:     "convert to float32[]",
+		},
+		{
+			Obj:      golist.NewList([]int32{10, 5, 25, 200}),
+			expected: golist.NewList([]float64{10, 5, 25, 200}),
+			desc:     "convert to Float64[]",
+		},
+		{
+			Obj:      golist.NewList([]int64{10, 5, 25, 200}),
+			expected: golist.NewList([]int{10, 5, 25, 200}),
+			desc:     "convert to int[]",
+		},
+		{
+			Obj:      golist.NewList([]float32{10, 5, 25, 200}),
+			expected: golist.NewList([]int32{10, 5, 25, 200}),
+			desc:     "convert to int32[]",
+		},
+		{
+			Obj:      golist.NewList([]float64{10, 5, 25, 200}),
+			expected: golist.NewList([]int64{10, 5, 25, 200}),
+			desc:     "convert to int64[]",
+		},
+		{
+			Obj:      golist.NewList([]float64{10, 5, 25, 200}),
+			expected: golist.NewList([]string{"10", "5", "25", "200"}),
+			desc:     "convert to string[]",
+		},
+		{
+			Obj:      golist.NewList([]string{"10", "05", "25", "200"}),
+			expected: golist.NewList([]float64{10, 5, 25, 200}),
+			desc:     "convert to float64[]",
+		},
+		{
+			Obj:      golist.NewList([]string{"Hello", "world"}),
+			expected: golist.NewList([]string{"Hello", "world"}),
+			desc:     "convert string[] to string[]",
+		},
+	}
+
+	t.Run(testCases[0].desc, func(t *testing.T) {
+		got, err := testCases[0].Obj.ConvertToSliceFloat32()
+		if err != nil {
+			t.Errorf("[Error ConvertToSlice](0) : %v", err)
+		}
+		gotList := golist.NewList(got)
+		if !gotList.IsEqual(testCases[0].expected) {
+			t.Errorf("Error ConvertToSlice](0) : Got: %v, Expected: %v.\n", got, testCases[1].expected)
+		}
+	})
+
+	t.Run(testCases[1].desc, func(t *testing.T) {
+		got, err := testCases[1].Obj.ConvertToSliceFloat64()
+		if err != nil {
+			t.Errorf("[Error ConvertToSlice](1) : %v", err)
+		}
+		gotList := golist.NewList(got)
+		if !gotList.IsEqual(testCases[1].expected) {
+			t.Errorf("Error ConvertToSlice](1) : Got: %v, Expected: %v.\n", got, testCases[1].expected)
+		}
+	})
+
+	t.Run(testCases[2].desc, func(t *testing.T) {
+		got, err := testCases[2].Obj.ConvertToSliceInt()
+		if err != nil {
+			t.Errorf("[Error ConvertToSlice](2) : %v", err)
+		}
+		gotList := golist.NewList(got)
+		if !gotList.IsEqual(testCases[2].expected) {
+			t.Errorf("Error ConvertToSlice](2) : Got: %v, Expected: %v.\n", got, testCases[2].expected)
+		}
+	})
+}

--- a/sliceConversion.go
+++ b/sliceConversion.go
@@ -1,0 +1,33 @@
+package golist
+
+import "github.com/emylincon/golist/core"
+
+// ConvertToSliceFloat32 converts golist to []float32
+func (arr *List) ConvertToSliceFloat32() ([]float32, error) {
+	return core.ConvertToFloat32(arr.list)
+}
+
+// ConvertToSliceFloat64 converts golist to []float64
+func (arr *List) ConvertToSliceFloat64() ([]float64, error) {
+	return core.ConvertToFloat64(arr.list)
+}
+
+// ConvertToSliceInt64 converts golist to []int64
+func (arr *List) ConvertToSliceInt64() ([]int64, error) {
+	return core.ConvertToInt64(arr.list)
+}
+
+// ConvertToSliceInt32 converts golist to []int32
+func (arr *List) ConvertToSliceInt32() ([]int32, error) {
+	return core.ConvertToInt32(arr.list)
+}
+
+// ConvertToSliceInt converts golist to []int
+func (arr *List) ConvertToSliceInt() ([]int, error) {
+	return core.ConvertToInt(arr.list)
+}
+
+// ConvertToSliceString converts golist to []string
+func (arr *List) ConvertToSliceString() ([]string, error) {
+	return core.ConvertToString(arr.list)
+}


### PR DESCRIPTION
# Convert golist to slice implementation
closes #121 
## `list.ConvertToSliceFloat32() ([]float32, error)`
Converts golist to []float32. Example
```golang
list := golist.NewList([]int{12,2})

slice, err := list.ConvertToSliceFloat32()
if err != nil {
    fmt.Println(err) // handle error
}
fmt.Printf("%T", slice) // []float32
```

## `list.ConvertToSliceFloat64() ([]float64, error)`
Converts golist to []float64. Example
```golang
list := golist.NewList([]int{12,2})

slice, err := list.ConvertToSliceFloat64()
if err != nil {
    fmt.Println(err) // handle error
}
fmt.Printf("%T", slice) // []float64
```

## `list.ConvertToSliceInt64() ([]int64, error)`
Converts golist to []int64. Example
```golang
list := golist.NewList([]int{12,2})

slice, err := list.ConvertToSliceInt64()
if err != nil {
    fmt.Println(err) // handle error
}
fmt.Printf("%T", slice) // []int64
```

## `list.ConvertToSliceInt32() ([]int32, error)`
Converts golist to []int32. Example
```golang
list := golist.NewList([]int{12,2})

slice, err := list.ConvertToSliceInt32()
if err != nil {
    fmt.Println(err) // handle error
}
fmt.Printf("%T", slice) // []int32
```

## `list.ConvertToSliceInt() ([]int, error)`
Converts golist to []int. Example
```golang
list := golist.NewList([]int{12,2})

slice, err := list.ConvertToSliceInt()
if err != nil {
    fmt.Println(err) // handle error
}
fmt.Printf("%T", slice) // []int
```

## `list.ConvertToSliceString() ([]string, error)`
Converts golist to []string. Example
```golang
list := golist.NewList([]int{12,2})

slice, err := list.ConvertToSliceString()
if err != nil {
    fmt.Println(err) // handle error
}
fmt.Printf("%T", slice) // []string
```