### PR TITLE
implemented diff feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -532,3 +532,15 @@ if err != nil {
 }
 fmt.Printf("%T", slice) // []string
 ```
+
+## `list.Difference(other *List) (*List, error)`
+Difference returns the elements in `list` that aren't in `other`. Example
+```golang
+list := golist.NewList([]int{1,2,3,4})
+other := golist.NewList([]int{3,4})
+diff, err := list.Difference(other)
+if err != nil {
+    fmt.Println(err) // handle error
+}
+fmt.Println(diff) // [1, 2]
+```

--- a/diff.go
+++ b/diff.go
@@ -1,0 +1,23 @@
+package golist
+
+// Difference returns the elements in `list` that aren't in `other`.
+func (arr *List) Difference(other *List) (*List, error) {
+	if arr.Type() != other.Type() {
+		return nil, ErrListsNotOfSameType
+	} else if arr.Type() == TypeListUnknown {
+		return nil, ErrTypeNotsupported
+	}
+	mb := make(map[interface{}]struct{}, other.Len())
+	for i := 0; i < other.Len(); i++ {
+		mb[other.Get(i)] = struct{}{}
+	}
+
+	diff, _ := arr.Copy()
+	diff.Clear()
+	for i := 0; i < arr.Len(); i++ {
+		if _, found := mb[arr.Get(i)]; !found {
+			diff.Append(arr.Get(i))
+		}
+	}
+	return diff, nil
+}

--- a/example_list_test.go
+++ b/example_list_test.go
@@ -75,6 +75,14 @@ func Example() {
 	}
 	fmt.Printf("%T\n", slice)
 
+	list = golist.NewList([]int{1, 2, 3, 4})
+	other := golist.NewList([]int{3, 4})
+	diff, err := list.Difference(other)
+	if err != nil {
+		fmt.Println(err) // handle error
+	}
+	fmt.Println(diff)
+
 	// Output:
 	// Get(0) : 1
 	// Index(2) : 1
@@ -87,4 +95,5 @@ func Example() {
 	// ListMultiplyNo : [2, 2]
 	// ListDivide : [4, 3]
 	// []string
+	// [1, 2]
 }

--- a/list_test.go
+++ b/list_test.go
@@ -954,3 +954,48 @@ func TestConvertToSlice(t *testing.T) {
 		}
 	})
 }
+
+func TestListDifference(t *testing.T) {
+
+	testCases := []struct {
+		Obj      *golist.List
+		other    *golist.List
+		expected *golist.List
+	}{
+		{
+			Obj:      golist.NewList([]int{2, 3, 4}),
+			other:    golist.NewList([]int{2, 1, 4}),
+			expected: golist.NewList([]int{3}),
+		},
+		{
+			Obj:      golist.NewList([]int32{2, 3, 4}),
+			other:    golist.NewList([]int32{2, 3, 4}),
+			expected: golist.NewList([]int32{}),
+		},
+		{
+			Obj:      golist.NewList([]int64{2, 3, 4}),
+			other:    golist.NewList([]int64{2, 3, 4}),
+			expected: golist.NewList([]int64{}),
+		},
+		{
+			Obj:      golist.NewList([]float32{2, 3, 4}),
+			other:    golist.NewList([]float32{2, 2, 4}),
+			expected: golist.NewList([]float32{3}),
+		},
+		{
+			Obj:      golist.NewList([]float64{2, 3, 4}),
+			other:    golist.NewList([]float64{1}),
+			expected: golist.NewList([]float64{2, 3, 4}),
+		},
+	}
+	for _, tC := range testCases {
+		got, err := tC.Obj.Difference(tC.other)
+		if err != nil {
+			t.Errorf("[Error Difference] : %v", err)
+		}
+		if !got.IsEqual(tC.expected) {
+			t.Errorf("[Error Difference] : Got: %v, Expected: %v.\n", got, tC.expected)
+		}
+
+	}
+}

--- a/string.go
+++ b/string.go
@@ -5,9 +5,12 @@ import (
 	"strings"
 )
 
-// String  :
+// String :
 // returns string representation of the list
 func (arr *List) String() string {
+	if arr.Len() == 0 {
+		return "[]"
+	}
 	switch list := arr.list.(type) {
 	case []string:
 		stringList := "["


### PR DESCRIPTION
closes #126 

## `list.Difference(other *List) (*List, error)`
Difference returns the elements in `list` that aren't in `other`. Example
```golang
list := golist.NewList([]int{1,2,3,4})
other := golist.NewList([]int{3,4})
diff, err := list.Difference(other)
if err != nil {
    fmt.Println(err) // handle error
}
fmt.Println(diff) // [1, 2]
```