### PR TITLE
implements differenceBoth

### DIFF
--- a/README.md
+++ b/README.md
@@ -550,7 +550,7 @@ DifferenceBoth returns the elements that aren't in both lists. Example
 ```golang
 list := golist.NewList([]int{1,2,3,4})
 other := golist.NewList([]int{3,4,5})
-diff, err := list.Difference(other)
+diff, err := list.DifferenceBoth(other)
 if err != nil {
     fmt.Println(err) // handle error
 }

--- a/README.md
+++ b/README.md
@@ -537,10 +537,22 @@ fmt.Printf("%T", slice) // []string
 Difference returns the elements in `list` that aren't in `other`. Example
 ```golang
 list := golist.NewList([]int{1,2,3,4})
-other := golist.NewList([]int{3,4})
+other := golist.NewList([]int{3,4,5})
 diff, err := list.Difference(other)
 if err != nil {
     fmt.Println(err) // handle error
 }
 fmt.Println(diff) // [1, 2]
+```
+
+## `list.DifferenceBoth(other *List) (*List, error)`
+DifferenceBoth returns the elements that aren't in both lists. Example
+```golang
+list := golist.NewList([]int{1,2,3,4})
+other := golist.NewList([]int{3,4,5})
+diff, err := list.Difference(other)
+if err != nil {
+    fmt.Println(err) // handle error
+}
+fmt.Println(diff) // [1, 2, 5]
 ```

--- a/diff.go
+++ b/diff.go
@@ -21,3 +21,31 @@ func (arr *List) Difference(other *List) (*List, error) {
 	}
 	return diff, nil
 }
+
+// DifferenceBoth returns the elements that aren't in both lists.
+func (arr *List) DifferenceBoth(other *List) (*List, error) {
+	if arr.Type() != other.Type() {
+		return nil, ErrListsNotOfSameType
+	} else if arr.Type() == TypeListUnknown {
+		return nil, ErrTypeNotsupported
+	}
+	diff, _ := arr.Copy()
+	diff.Clear()
+	m := map[interface{}]int{}
+
+	for i := 0; i < arr.Len(); i++ {
+		m[arr.Get(i)] = 1
+	}
+	for i := 0; i < other.Len(); i++ {
+		m[other.Get(i)] = m[other.Get(i)] + 1
+	}
+
+	for mKey, mVal := range m {
+		if mVal == 1 {
+			diff.Append(mKey)
+		}
+	}
+
+	return diff, nil
+
+}

--- a/list.go
+++ b/list.go
@@ -27,6 +27,7 @@ type Lists interface {
 	Copy() (*List, error)                                // return a copy of list
 	Count(element interface{}) int                       // count how many times an item appears in list
 	Difference(other *List) (*List, error)               // Difference returns the elements in `list` that aren't in `other`.
+	DifferenceBoth(other *List) (*List, error)           // DifferenceBoth returns the elements that aren't in both lists.
 	Extend(element interface{}) error                    // extend list
 	GCF() (interface{}, error)                           // gcf of list
 	Get(index int) interface{}                           // get item with index

--- a/list_test.go
+++ b/list_test.go
@@ -993,3 +993,49 @@ func TestListDifference(t *testing.T) {
 
 	}
 }
+
+func TestListDifferenceBoth(t *testing.T) {
+
+	testCases := []struct {
+		Obj      *golist.List
+		other    *golist.List
+		expected *golist.List
+	}{
+		{
+			Obj:      golist.NewList([]int{2, 3, 4}),
+			other:    golist.NewList([]int{2, 1, 4}),
+			expected: golist.NewList([]int{1, 3}),
+		},
+		{
+			Obj:      golist.NewList([]int32{2, 3, 4}),
+			other:    golist.NewList([]int32{2, 3, 4}),
+			expected: golist.NewList([]int32{}),
+		},
+		{
+			Obj:      golist.NewList([]int64{2, 3, 4}),
+			other:    golist.NewList([]int64{2, 3, 4}),
+			expected: golist.NewList([]int64{}),
+		},
+		{
+			Obj:      golist.NewList([]float32{2, 3, 4}),
+			other:    golist.NewList([]float32{2, 2, 4}),
+			expected: golist.NewList([]float32{3}),
+		},
+		{
+			Obj:      golist.NewList([]float64{2, 3, 4}),
+			other:    golist.NewList([]float64{1}),
+			expected: golist.NewList([]float64{1, 2, 3, 4}),
+		},
+	}
+	for _, tC := range testCases {
+		got, err := tC.Obj.DifferenceBoth(tC.other)
+		if err != nil {
+			t.Errorf("[Error DifferenceBoth] : %v", err)
+		}
+		got.Sort(false)
+		if !got.IsEqual(tC.expected) {
+			t.Errorf("[Error DifferenceBoth] : Got: %v, Expected: %v.\n", got, tC.expected)
+		}
+
+	}
+}


### PR DESCRIPTION
closes #130 
## `list.DifferenceBoth(other *List) (*List, error)`
DifferenceBoth returns the elements that aren't in both lists. Example
```golang
list := golist.NewList([]int{1,2,3,4})
other := golist.NewList([]int{3,4,5})
diff, err := list.Difference(other)
if err != nil {
    fmt.Println(err) // handle error
}
fmt.Println(diff) // [1, 2, 5]
```